### PR TITLE
Add RHACS instance id label

### DIFF
--- a/resources/prometheus/billing-rules.yaml
+++ b/resources/prometheus/billing-rules.yaml
@@ -9,5 +9,12 @@ spec:
     - name: rhacs-cluster-billing
       rules:
         - expr: |
-            sum(avg_over_time(rox_central_cluster_metrics_cpu_capacity{ClusterID!=""}[1h])) by(ClusterID)
+            label_replace(
+              sum by (rhacs_instance_id) (
+                avg by (ClusterID, rhacs_instance_id) (
+                  avg_over_time(rox_central_cluster_metrics_cpu_capacity{ClusterID!=""}[1h])
+                )
+              ),
+              "_id", "$1", "rhacs_instance_id", "(.*)"
+            )
           record: "rhacs:rox_central_cluster_metrics_cpu_capacity:avg_over_time1h"

--- a/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
@@ -20,3 +20,8 @@ spec:
         - sourceLabels: [container]
           action: replace
           targetLabel: job
+
+        - sourceLabels: [namespace]
+          action: replace
+          regex: .+-(.+)
+          targetLabel: rhacs_instance_id

--- a/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
@@ -20,3 +20,8 @@ spec:
         - sourceLabels: [container]
           action: replace
           targetLabel: job
+
+        - sourceLabels: [namespace]
+          action: replace
+          regex: .+-(.+)
+          targetLabel: rhacs_instance_id


### PR DESCRIPTION
We decided to provide Subscription Watch with a total value of the
billing metric per RHACS instance, instead of breaking it down
further by ClusterID.

This also fixes the issue described in
https://issues.redhat.com/browse/ROX-11589 by adding another `avg`.