### PR TITLE
ROX-11614: Add PagerDuty secret name to the configuration.

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -15,7 +15,9 @@
       "remoteWrite": "prometheus/remote-write.yaml",
       "overridePrometheusPvcSize": "250Gi"
     },
-    "alertmanager": {},
+    "alertmanager": {
+      "pagerDutySecretName": "rhacs-pagerduty"
+    },
     "grafana": {
       "dashboards": [
         "grafana/rhacs-central-dashboard.yaml",


### PR DESCRIPTION
* Hardcoded secret name, as in the `acs-fleet-manager` helm chart and openshift template (coming soon);
* Namespace is not set, assuming it is the same as the operator;
* Dead Man's Snitch URL is not set, as there's no account yet. The operator will set the URL to "http://dummy', as before;
* scripts and resources are not modified due to #16.