### PR TITLE
ROX-11939: Enable pod monitors in index.json

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -3,8 +3,11 @@
   "config": {
     "prometheus": {
       "pod_monitors": [
+        "prometheus/pod_monitors/prometheus-self-metrics.yaml",
         "prometheus/pod_monitors/rhacs-central-metrics.yaml",
-        "prometheus/pod_monitors/prometheus-self-metrics.yaml"
+        "prometheus/pod_monitors/rhacs-fleetshard-operator-metrics.yaml",
+        "prometheus/pod_monitors/rhacs-fleetshard-sync-metrics.yaml",
+        "prometheus/pod_monitors/rhacs-scanner-metrics.yaml"
       ],
       "rules": [
         "prometheus/prometheus-rules.yaml",


### PR DESCRIPTION
The pod monitors for scanner and fleetshard-* services were defined as
resources, but not enabled in `index.json`.