### PR TITLE
Add fleetshard sync alerts

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -3,7 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app: strimzi
-  name: rhacs-central-prometheus-rules
+  name: rhacs-data-plane-prometheus-rules
 spec:
   groups:
     - name: rhacs-central
@@ -16,7 +16,7 @@ spec:
             severity: critical
           annotations:
             summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
-            description: 'During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful.'
+            description: "During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSCentralContainerDown
           expr: |
@@ -67,7 +67,7 @@ spec:
             severity: critical
           annotations:
             summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
-            description: 'During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful.'
+            description: "During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSScannerContainerDown
           expr: |
@@ -112,6 +112,7 @@ spec:
             summary: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
             description: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 60 minutes."
             sop_url: "" # TODO: Add SOP
+
         - alert: RHACSFleetshardSyncScrapeFailed
           expr: |
             avg_over_time(up{pod=~"fleetshard-sync-.*"}[10m]) < 0.25 or absent(up{pod=~"fleetshard-sync-.*"})
@@ -139,6 +140,26 @@ spec:
           annotations:
             summary: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
             description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 60 minutes."
+            sop_url: "" # TODO: Add SOP
+        - alert: RHACSFleetshardSyncReconciliationErrors
+          expr: |
+            acs_fleetshard_central_errors_per_reconciliations:ratio_rate10m > 0.01
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` failed to reconcile Central instances."
+            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has a reconciliation error rate of {{ $value | humanizePercentage }} over the last 10 minutes."
+            sop_url: "" # TODO: Add SOP
+        - alert: RHACSFleetshardSyncFleetManagerRequestErrors
+          expr: |
+            acs_fleetshard_fleet_manager_errors_per_requests:ratio_rate10m > 0.01
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` failed to reach fleet manager."
+            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has a fleet manager request error rate of {{ $value | humanizePercentage }} over the last 10 minutes."
             sop_url: "" # TODO: Add SOP
 
     - name: deadmanssnitch

--- a/resources/prometheus/rhacs-recording-rules.yaml
+++ b/resources/prometheus/rhacs-recording-rules.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: strimzi
+  name: rhacs-prometheus-recording-rules
+spec:
+  groups:
+    - name: rhacs-fleetshard-recording-rules
+      rules:
+        - expr: |2
+              rate(acs_fleetshard_total_central_reconcilation_errors[10m])
+            /
+              rate(acs_fleetshard_total_central_reconcilations[10m])
+          labels:
+          record: acs_fleetshard_central_errors_per_reconciliations:ratio_rate10m
+        - expr: |2
+              rate(acs_fleetshard_total_fleet_manager_request_errors[10m])
+            /
+              rate(acs_fleetshard_total_fleet_manager_requests[10m])
+          labels:
+          record: acs_fleetshard_fleet_manager_errors_per_requests:ratio_rate10m

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconciliationErrors.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconciliationErrors.yaml
@@ -1,0 +1,27 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: acs_fleetshard_central_errors_per_reconciliations:ratio_rate10m{namespace="rhacs", pod="fleetshard-sync-1234", container="fleetshard-sync"}
+        values: "0+0x5 0+0.01x15"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RHACSFleetshardSyncReconciliationErrors
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: RHACSFleetshardSyncReconciliationErrors
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSFleetshardSyncReconciliationErrors
+              container: fleetshard-sync
+              namespace: rhacs
+              pod: fleetshard-sync-1234
+              severity: critical
+            exp_annotations:
+              summary: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` failed to reconcile Central instances."
+              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has a reconciliation error rate of 9% over the last 10 minutes."
+              sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncFleetManagerRequestErrors.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncFleetManagerRequestErrors.yaml
@@ -1,0 +1,27 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: acs_fleetshard_fleet_manager_errors_per_requests:ratio_rate10m{namespace="rhacs", pod="fleetshard-sync-1234", container="fleetshard-sync"}
+        values: "0+0x5 0+0.01x15"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: RHACSFleetshardSyncFleetManagerRequestErrors
+        exp_alerts: []
+      - eval_time: 15m
+        alertname: RHACSFleetshardSyncFleetManagerRequestErrors
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSFleetshardSyncFleetManagerRequestErrors
+              container: fleetshard-sync
+              namespace: rhacs
+              pod: fleetshard-sync-1234
+              severity: critical
+            exp_annotations:
+              summary: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` failed to reach fleet manager."
+              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has a fleet manager request error rate of 9% over the last 10 minutes."
+              sop_url: ""


### PR DESCRIPTION
More elaborate alerts based on SLOs and burn rates will be added later. This is meant as a quick win by adding rudimentary alerts to get notified of failures in fleetshard-sync.