### PR TITLE
Remove fleetshard-operator from pod monitors

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -5,7 +5,6 @@
       "pod_monitors": [
         "prometheus/pod_monitors/prometheus-self-metrics.yaml",
         "prometheus/pod_monitors/rhacs-central-metrics.yaml",
-        "prometheus/pod_monitors/rhacs-fleetshard-operator-metrics.yaml",
         "prometheus/pod_monitors/rhacs-fleetshard-sync-metrics.yaml",
         "prometheus/pod_monitors/rhacs-scanner-metrics.yaml"
       ],


### PR DESCRIPTION
This prevented the observability operator config from being pulled correctly. Interestingly, this was somehow converted to a 403 error code.

This was forgotten in #19 