### PR TITLE
Make alerts more robust against oscillating pods

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -10,23 +10,23 @@ spec:
       rules:
         - alert: RHACSCentralScrapeFailed
           expr: |
-            avg_over_time(up{pod=~"central-.*"}[10m]) < 0.25
+            avg_over_time(up{pod=~"central-.*"}[3m]) < 0.5 and ON(pod) kube_pod_container_status_ready{container="central"} == 1
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
-            description: "During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful."
+            description: "During the last 3 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 50% of scrapes are successful."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSCentralContainerDown
           expr: |
-            avg_over_time(kube_pod_container_status_ready{container="central"}[10m]) < 0.5
+            avg_over_time(kube_pod_container_status_ready{container="central"}[3m]) < 0.5
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` is down or in a CrashLoopBackOff status."
-            description: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+            description: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSCentralContainerFrequentlyRestarting
           expr: |
@@ -61,23 +61,23 @@ spec:
       rules:
         - alert: RHACSScannerScrapeFailed
           expr: |
-            avg_over_time(up{pod=~"scanner-.*"}[10m]) < 0.25
+            avg_over_time(up{pod=~"scanner-.*"}[3m]) < 0.5 and ON(pod) kube_pod_container_status_ready{pod=~"scanner.*", container=~"scanner|db"} == 1
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
-            description: "During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 25% of scrapes are successful."
+            description: "During the last 3 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 50% of scrapes are successful."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSScannerContainerDown
           expr: |
-            avg_over_time(kube_pod_container_status_ready{pod=~"scanner.*", container=~"scanner|db"}[10m]) < 0.5
+            avg_over_time(kube_pod_container_status_ready{pod=~"scanner.*", container=~"scanner|db"}[3m]) < 0.5
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` is down or in a CrashLoopBackOff status."
-            description: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+            description: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSScannerContainerFrequentlyRestarting
           expr: |
@@ -94,13 +94,13 @@ spec:
       rules:
         - alert: RHACSFleetshardOperatorContainerDown
           expr: |
-            avg_over_time(kube_pod_container_status_ready{pod=~"rhacs-operator-controller-manager-.*"}[10m]) < 0.5
+            avg_over_time(kube_pod_container_status_ready{pod=~"rhacs-operator-controller-manager-.*"}[3m]) < 0.5
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` is down or in a CrashLoopBackOff status."
-            description: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+            description: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardOperatorContainerFrequentlyRestarting
           expr: |
@@ -115,23 +115,23 @@ spec:
 
         - alert: RHACSFleetshardSyncScrapeFailed
           expr: |
-            avg_over_time(up{pod=~"fleetshard-sync-.*"}[10m]) < 0.25 or absent(up{pod=~"fleetshard-sync-.*"})
+            (avg_over_time(up{pod=~"fleetshard-sync-.*"}[3m]) < 0.5 and ON(pod) kube_pod_container_status_ready{pod=~"fleetshard-sync-.*"} == 1) or absent(up{pod=~"fleetshard-sync-.*"})
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
-            description: "The scrape target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` is either down, or during the last 10 minutes less than 25% of scrapes were successful."
+            description: "The scrape target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` is either down, or during the last 3 minutes less than 50% of scrapes were successful."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardSyncContainerDown
           expr: |
-            avg_over_time(kube_pod_container_status_ready{pod=~"fleetshard-sync-.*"}[10m]) < 0.5
+            avg_over_time(kube_pod_container_status_ready{pod=~"fleetshard-sync-.*"}[3m]) < 0.5
           for: 5m
           labels:
             severity: critical
           annotations:
             summary: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` is down or in a CrashLoopBackOff status."
-            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 5 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardSyncContainerFrequentlyRestarting
           expr: increase(kube_pod_container_status_restarts_total{pod=~"fleetshard-sync-.*"}[60m]) > 3

--- a/resources/prometheus/unit_tests/RHACSCentralContainerDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralContainerDown.yaml
@@ -23,5 +23,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Central container `central-1234/central` in namespace `rhacs-1234` is down or in a CrashLoopBackOff status."
-              description: "Central container `central-1234/central` in namespace `rhacs-1234` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+              description: "Central container `central-1234/central` in namespace `rhacs-1234` has been down or in a CrashLoopBackOff status for at least 5 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSCentralScrapeFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralScrapeFailed.yaml
@@ -7,12 +7,14 @@ tests:
   - interval: 1m
     input_series:
       - series: up{namespace="rhacs-1234", pod="central-1234-5678", instance="1.2.3.4:9090"}
-        values: "0+0x8 1+0x15"
+        values: "0+0x4 1+0x6"
+      - series: kube_pod_container_status_ready{namespace="rhacs-1234", pod="central-1234-5678", container="central"}
+        values: "1+0x10"
     alert_rule_test:
       - eval_time: 3m
         alertname: RHACSCentralScrapeFailed
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 5m
         alertname: RHACSCentralScrapeFailed
         exp_alerts:
           - exp_labels:
@@ -23,5 +25,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Prometheus unable to scrape metrics from target `central-1234-5678` in namespace `rhacs-1234`."
-              description: "During the last 10 minutes, only `18.18%` of scrapes of target `central-1234-5678` in namespace `rhacs-1234` were successful. This alert is raised when less than 25% of scrapes are successful."
+              description: "During the last 3 minutes, only `25%` of scrapes of target `central-1234-5678` in namespace `rhacs-1234` were successful. This alert is raised when less than 50% of scrapes are successful."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardOperatorContainerDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardOperatorContainerDown.yaml
@@ -25,7 +25,7 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` is down or in a CrashLoopBackOff status."
-              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes."
               sop_url: ""
           - exp_labels:
               alertname: RHACSFleetshardOperatorContainerDown
@@ -35,5 +35,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` is down or in a CrashLoopBackOff status."
-              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncContainerDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncContainerDown.yaml
@@ -23,5 +23,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` is down or in a CrashLoopBackOff status."
-              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has been down or in a CrashLoopBackOff status for at least 5 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncScrapeFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncScrapeFailed.yaml
@@ -7,12 +7,14 @@ tests:
   - interval: 1m
     input_series:
       - series: up{namespace="rhacs", pod="fleetshard-sync-1234", instance="1.2.3.4:9090"}
-        values: "0+0x8 1+0x15"
+        values: "0+0x4 1+0x6"
+      - series: kube_pod_container_status_ready{namespace="rhacs", pod="fleetshard-sync-1234"}
+        values: "1+0x10"
     alert_rule_test:
       - eval_time: 3m
         alertname: RHACSFleetshardSyncScrapeFailed
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 5m
         alertname: RHACSFleetshardSyncScrapeFailed
         exp_alerts:
           - exp_labels:
@@ -23,5 +25,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Prometheus unable to scrape metrics from target `fleetshard-sync-1234` in namespace `rhacs`."
-              description: "The scrape target `fleetshard-sync-1234` in namespace `rhacs` is either down, or during the last 10 minutes less than 25% of scrapes were successful."
+              description: "The scrape target `fleetshard-sync-1234` in namespace `rhacs` is either down, or during the last 3 minutes less than 50% of scrapes were successful."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSScannerContainerDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSScannerContainerDown.yaml
@@ -23,5 +23,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Scanner container `scanner-1234/scanner` in namespace `rhacs-1234` is down or in a CrashLoopBackOff status."
-              description: "Scanner container `scanner-1234/scanner` in namespace `rhacs-1234` has been down or in a CrashLoopBackOff status for at least 5 minutes of the last 10 minutes."
+              description: "Scanner container `scanner-1234/scanner` in namespace `rhacs-1234` has been down or in a CrashLoopBackOff status for at least 5 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSScannerScrapeFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSScannerScrapeFailed.yaml
@@ -7,12 +7,14 @@ tests:
   - interval: 1m
     input_series:
       - series: up{namespace="rhacs-1234", pod="scanner-1234-5678", instance="1.2.3.4:9090"}
-        values: "0+0x8 1+0x15"
+        values: "0+0x4 1+0x6"
+      - series: kube_pod_container_status_ready{namespace="rhacs-1234", pod="scanner-1234-5678", container="scanner"}
+        values: "1+0x10"
     alert_rule_test:
       - eval_time: 3m
         alertname: RHACSScannerScrapeFailed
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 5m
         alertname: RHACSScannerScrapeFailed
         exp_alerts:
           - exp_labels:
@@ -23,5 +25,5 @@ tests:
               severity: critical
             exp_annotations:
               summary: "Prometheus unable to scrape metrics from target `scanner-1234-5678` in namespace `rhacs-1234`."
-              description: "During the last 10 minutes, only `18.18%` of scrapes of target `scanner-1234-5678` in namespace `rhacs-1234` were successful. This alert is raised when less than 25% of scrapes are successful."
+              description: "During the last 3 minutes, only `25%` of scrapes of target `scanner-1234-5678` in namespace `rhacs-1234` were successful. This alert is raised when less than 50% of scrapes are successful."
               sop_url: ""


### PR DESCRIPTION
The time average is kept to alert on oscillating pods. However, the interval is reduced below the evaluation threshold to prevent single data points from skewing the alert triggers.

In addition, scrape failure alerts are now only triggered if the pod was in ready state.