### PR TITLE
make sure probe failure timestamp is non-zero

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -176,6 +176,7 @@ spec:
       rules:
         - alert: RHACSProbeRunFailed
           expr: acs_probe_last_failure_timestamp > 0 and acs_probe_last_failure_timestamp >= acs_probe_last_success_timestamp
+          for: 10m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
@@ -7,17 +7,17 @@ tests:
   - interval: 1m
     input_series:
       - series: acs_probe_last_failure_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0 0+0x5 7+0x15"
+        values: "0+0x10 0+0x5 7+0x20"
       - series: acs_probe_last_success_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0 1+1x5 6+0x15"
+        values: "0+0x10 1+1x5 6+0x20"
     alert_rule_test:
       - eval_time: 0m
         alertname: RHACSProbeRunFailed
         exp_alerts: []
-      - eval_time: 5m
+      - eval_time: 15m
         alertname: RHACSProbeRunFailed
         exp_alerts: []
-      - eval_time: 10m
+      - eval_time: 30m
         alertname: RHACSProbeRunFailed
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
This prevents an alert going off when both failures and success are reported as 0.

Also add a 10m grace period to prevent alerts from aborted runs due to pod rescheduling.