### PR TITLE
Introduce production branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Resources are maintained in the `/resources` folder. Sub folders contain the fol
 The observability stack is installed by the [data plane terraforming Helm chart](https://github.com/stackrox/acs-fleet-manager/tree/main/dp-terraform/helm/rhacs-terraform).
 Please follow the instructions in the fleet manager repository to install the Helm chart.
 
+## Branches
+
+The ACS cloud service data plane `stage` environment tracks the `master` branch. Conversely, the production environment tracks the `production` branch.
+Changes are merged from the `master` to the `production` branch after sufficient soak time on the stage environment.
+
 ## Contributing
 
 This repository makes use of [pre-commit](https://pre-commit.com/) framework. Refer to the [installation instructions](https://pre-commit.com/#installation) for further information.


### PR DESCRIPTION
We currently pin the git commit for our data plane production environment. This creates some manual effort when updating to a new revision. By introducing a separate production branch, we do not have to update and run the observability Helm chart. Instead, we can simply update the revision by merging changes into the `production` branch. The configuration pull mechanism of the observability operator will then deploy the changes without needing a separate run of the data plane deployment pipeline, and the deployment of observability resources is decoupled from the data plane terraforming.

After this change is merged, I will create the `production` branch based on the current `master`.