### PR TITLE
Improve remote write failure alert

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -234,15 +234,11 @@ spec:
 
         - alert: ObservabilityOperatorRemoteWriteFailure
           expr: >-
-            (sum(rate(prometheus_remote_storage_retried_samples_total[5m])) /
-            sum(rate(prometheus_remote_storage_samples_in_total[5m])) > 0.2)
-            OR
-            (sum(rate(prometheus_remote_storage_failed_samples_total[5m])) /
-            sum(rate(prometheus_remote_storage_samples_in_total[5m])) > 0.2)
-          for: 10m
+            obs_operator:prometheus_remote_storage_succeeded_samples:ratio_rate1h < 0.25
+          for: 1h
           labels:
             severity: critical
           annotations:
             summary: "The Observability Operator's Prometheus is failing to remote write to Observatorium."
-            description: "The Prometheus remote write had a failure rate above 20% for more than 10 minutes."
+            description: "The Prometheus remote write success rate is `{{ $value | humanizePercentage }}`."
             sop_url: "" # TODO: Add SOP

--- a/resources/prometheus/rhacs-recording-rules.yaml
+++ b/resources/prometheus/rhacs-recording-rules.yaml
@@ -20,3 +20,11 @@ spec:
               rate(acs_fleetshard_total_fleet_manager_requests[10m])
           labels:
           record: acs_fleetshard_fleet_manager_errors_per_requests:ratio_rate10m
+
+    - name: observability-operator
+      rules:
+        - expr: |2
+              sum(rate(prometheus_remote_storage_succeeded_samples_total{namespace="rhacs-observability"}[1h]))
+            /
+              sum(rate(prometheus_remote_storage_samples_in_total{namespace="rhacs-observability"}[1h]))
+          record: obs_operator:prometheus_remote_storage_succeeded_samples:ratio_rate1h

--- a/resources/prometheus/unit_tests/ObservabilityOperatorRemoteWriteFailure.yaml
+++ b/resources/prometheus/unit_tests/ObservabilityOperatorRemoteWriteFailure.yaml
@@ -1,43 +1,25 @@
 rule_files:
   - /tmp/prometheus-rules-test.yaml
+  - /tmp/recording-rules-test.yaml
 
 evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: prometheus_remote_storage_failed_samples_total
-        values: "1+0x12 1+5x12"
-      - series: prometheus_remote_storage_samples_in_total
-        values: "1+1x12 11+9.5x12"
+      - series: prometheus_remote_storage_succeeded_samples_total{namespace="rhacs-observability"}
+        values: "1+100x30 3000+10x150"
+      - series: prometheus_remote_storage_samples_in_total{namespace="rhacs-observability"}
+        values: "1+100x180"
     alert_rule_test:
-      - eval_time: 12m
+      - eval_time: 60m
         alertname: ObservabilityOperatorRemoteWriteFailure
         exp_alerts: []
-      - eval_time: 24m
+      - eval_time: 160m
         alertname: ObservabilityOperatorRemoteWriteFailure
         exp_alerts:
           - exp_labels:
               severity: critical
             exp_annotations:
               summary: "The Observability Operator's Prometheus is failing to remote write to Observatorium."
-              description: "The Prometheus remote write had a failure rate above 20% for more than 10 minutes."
-              sop_url: ""
-  - interval: 1m
-    input_series:
-      - series: prometheus_remote_storage_retried_samples_total
-        values: "1+0x12 1+5x12"
-      - series: prometheus_remote_storage_samples_in_total
-        values: "1+1x12 11+9.5x12"
-    alert_rule_test:
-      - eval_time: 12m
-        alertname: ObservabilityOperatorRemoteWriteFailure
-        exp_alerts: []
-      - eval_time: 24m
-        alertname: ObservabilityOperatorRemoteWriteFailure
-        exp_alerts:
-          - exp_labels:
-              severity: critical
-            exp_annotations:
-              summary: "The Observability Operator's Prometheus is failing to remote write to Observatorium."
-              description: "The Prometheus remote write had a failure rate above 20% for more than 10 minutes."
+              description: "The Prometheus remote write success rate is `10%`."
               sop_url: ""

--- a/scripts/test-prom-rules.sh
+++ b/scripts/test-prom-rules.sh
@@ -9,6 +9,7 @@ set -eu
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
 
 yq eval '.spec' "${SCRIPT_DIR}"/../resources/prometheus/prometheus-rules.yaml >/tmp/prometheus-rules-test.yaml
+yq eval '.spec' "${SCRIPT_DIR}"/../resources/prometheus/rhacs-recording-rules.yaml >/tmp/recording-rules-test.yaml
 for f in "${SCRIPT_DIR}"/../resources/prometheus/unit_tests/*; do
 	echo "$f"
 	promtool test rules "${f}"


### PR DESCRIPTION
This is a follow up to the acscs-nov-30 incident.

* Simplify the alert by introducing a recording that is based on the successful writes, rather than retry and failure count.
* Make the alert less sensitive by increasing the time to trigger to 1 hour and allowing a failure rate of up to 75%.