### PR TITLE
increase alert trigger time for probe failure

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -176,7 +176,7 @@ spec:
       rules:
         - alert: RHACSProbeRunFailed
           expr: acs_probe_last_failure_timestamp > 0 and acs_probe_last_failure_timestamp >= acs_probe_last_success_timestamp
-          for: 10m
+          for: 30m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
@@ -7,17 +7,17 @@ tests:
   - interval: 1m
     input_series:
       - series: acs_probe_last_failure_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0+0x10 0+0x5 7+0x20"
+        values: "0+0x10 0+0x15 7+0x60"
       - series: acs_probe_last_success_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0+0x10 1+1x5 6+0x20"
+        values: "0+0x10 1+1x15 6+0x60"
     alert_rule_test:
       - eval_time: 0m
         alertname: RHACSProbeRunFailed
         exp_alerts: []
-      - eval_time: 15m
+      - eval_time: 30m
         alertname: RHACSProbeRunFailed
         exp_alerts: []
-      - eval_time: 30m
+      - eval_time: 60m
         alertname: RHACSProbeRunFailed
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
With the switch to RDS, the central creation time increased from ~5 minutes to ~15 minutes. This change increases the trigger time, such that we have more time to recover in the next probe run before an alert is raised. The trade off is a longer time to alert in case of real incidents. However, I think that is worth it because currently we cannot perform rolling updates of fleet-shard sync, and therefore might trigger an alert on every deployment with the current settings.