### PR TITLE
ROX-12344: Scrape rhacs metric labels

### DIFF
--- a/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
@@ -18,10 +18,21 @@ spec:
           regex: endpoint
 
         - sourceLabels: [container]
-          action: replace
           targetLabel: job
 
-        - sourceLabels: [namespace]
-          action: replace
-          regex: .+-(.+)
+        - action: labelmap
+          regex: __meta_kubernetes_pod_annotation_rhacs_redhat_com_(.+)
+          replacement: rhacs_${1}
+
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_rhacs_redhat_com_(.+)
+          replacement: rhacs_${1}
+
+        - sourceLabels: [rhacs_tenant]
           targetLabel: rhacs_instance_id
+
+        - action: labeldrop
+          regex: rhacs_tenant
+
+        - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_version]
+          targetLabel: rhacs_version

--- a/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
@@ -18,10 +18,21 @@ spec:
           regex: endpoint
 
         - sourceLabels: [container]
-          action: replace
           targetLabel: job
 
-        - sourceLabels: [namespace]
-          action: replace
-          regex: .+-(.+)
+        - action: labelmap
+          regex: __meta_kubernetes_pod_annotation_rhacs_redhat_com_(.+)
+          replacement: rhacs_${1}
+
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_rhacs_redhat_com_(.+)
+          replacement: rhacs_${1}
+
+        - sourceLabels: [rhacs_tenant]
           targetLabel: rhacs_instance_id
+
+        - action: labeldrop
+          regex: rhacs_tenant
+
+        - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_version]
+          targetLabel: rhacs_version


### PR DESCRIPTION
Follow up to new rhacs labels and annotations added in https://github.com/stackrox/acs-fleet-manager/pull/684

Example of new labels as they appear on the final metric series:

```
{rhacs_org_id="11009103", rhacs_org_name="Red Hat1", rhacs_version="3.73.1"}
```