### PR TITLE
Optimize dashboard variable query

### DIFF
--- a/resources/grafana/rhacs-central-dashboard.yaml
+++ b/resources/grafana/rhacs-central-dashboard.yaml
@@ -4475,7 +4475,7 @@ spec:
               "type": "prometheus",
               "uid": "PBFA97CFB590B2093"
             },
-            "definition": "label_values(rhacs_org_name)",
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\"}, rhacs_org_name)",
             "description": "Red Hat SSO Organisation Name",
             "hide": 0,
             "includeAll": true,
@@ -4484,7 +4484,7 @@ spec:
             "name": "org_name",
             "options": [],
             "query": {
-              "query": "label_values(rhacs_org_name)",
+              "query": "label_values(process_cpu_seconds_total{job=\"central\"}, rhacs_org_name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
@@ -4507,7 +4507,7 @@ spec:
               "type": "prometheus",
               "uid": "PBFA97CFB590B2093"
             },
-            "definition": "label_values({rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
             "description": "Red Hat SSO Organisation ID",
             "hide": 0,
             "includeAll": true,
@@ -4516,35 +4516,7 @@ spec:
             "name": "org_id",
             "options": [],
             "query": {
-              "query": "label_values({rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
-              "refId": "StandardVariableQuery"
-            },
-            "refresh": 1,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "type": "query"
-          },
-          {
-            "current": {
-              "selected": true,
-              "text": "ce90s406mnv90blbnu20",
-              "value": "ce90s406mnv90blbnu20"
-            },
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PBFA97CFB590B2093"
-            },
-            "definition": "label_values({rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
-            "description": "RHACS Central Instance ID",
-            "hide": 0,
-            "includeAll": false,
-            "label": "Central",
-            "multi": false,
-            "name": "instance_id",
-            "options": [],
-            "query": {
-              "query": "label_values({rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
+              "query": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
@@ -4556,6 +4528,34 @@ spec:
           {
             "current": {
               "selected": false,
+              "text": "ce90s406mnv90blbnu20",
+              "value": "ce90s406mnv90blbnu20"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "PBFA97CFB590B2093"
+            },
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
+            "description": "RHACS Central Instance ID",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Central",
+            "multi": false,
+            "name": "instance_id",
+            "options": [],
+            "query": {
+              "query": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": true,
               "text": [
                 "All"
               ],
@@ -4588,7 +4588,7 @@ spec:
           },
           {
             "current": {
-              "selected": false,
+              "selected": true,
               "text": [
                 "All"
               ],
@@ -4650,6 +4650,6 @@ spec:
       "timezone": "",
       "title": "RHACS Dataplane - Central Metrics",
       "uid": "gn38yKZnk",
-      "version": 4,
+      "version": 5,
       "weekStart": ""
     }

--- a/resources/grafana/rhacs-cluster-overview-dashboard.yaml
+++ b/resources/grafana/rhacs-cluster-overview-dashboard.yaml
@@ -35,7 +35,7 @@ spec:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 7,
+      "id": 6,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -234,7 +234,7 @@ spec:
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "count by (namespace) (kube_pod_container_status_ready{namespace=~\"rhacs-$instance_id\", container=\"central\", job=~\"kube-state-metrics\"}) * on(namespace) group_left(rhacs_org_name) count by (namespace, rhacs_org_name) (process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"central\", rhacs_org_id=~\"$org_id\"})",
+              "expr": "count by (rhacs_org_name) (count by (namespace) (kube_pod_container_status_ready{namespace=~\"rhacs-$instance_id\", container=\"central\", job=~\"kube-state-metrics\"}) * on(namespace) group_left(rhacs_org_name) count by (namespace, rhacs_org_name) (process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"central\", rhacs_org_id=~\"$org_id\"}))",
               "interval": "",
               "legendFormat": "{{rhacs_org_name}}",
               "range": true,
@@ -972,7 +972,7 @@ spec:
               "type": "prometheus",
               "uid": "PBFA97CFB590B2093"
             },
-            "definition": "label_values(rhacs_org_name)",
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\"}, rhacs_org_name)",
             "description": "Red Hat SSO Organisation Name",
             "hide": 0,
             "includeAll": true,
@@ -981,7 +981,7 @@ spec:
             "name": "org_name",
             "options": [],
             "query": {
-              "query": "label_values(rhacs_org_name)",
+              "query": "label_values(process_cpu_seconds_total{job=\"central\"}, rhacs_org_name)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
@@ -992,7 +992,7 @@ spec:
           },
           {
             "current": {
-              "selected": false,
+              "selected": true,
               "text": [
                 "All"
               ],
@@ -1004,7 +1004,7 @@ spec:
               "type": "prometheus",
               "uid": "PBFA97CFB590B2093"
             },
-            "definition": "label_values({rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
             "description": "Red Hat SSO Organisation ID",
             "hide": 0,
             "includeAll": true,
@@ -1013,7 +1013,7 @@ spec:
             "name": "org_id",
             "options": [],
             "query": {
-              "query": "label_values({rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
+              "query": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\"}, rhacs_org_id)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
@@ -1024,7 +1024,7 @@ spec:
           },
           {
             "current": {
-              "selected": false,
+              "selected": true,
               "text": [
                 "All"
               ],
@@ -1036,7 +1036,7 @@ spec:
               "type": "prometheus",
               "uid": "PBFA97CFB590B2093"
             },
-            "definition": "label_values({rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
+            "definition": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
             "description": "RHACS Central Instance ID",
             "hide": 0,
             "includeAll": true,
@@ -1045,7 +1045,7 @@ spec:
             "name": "instance_id",
             "options": [],
             "query": {
-              "query": "label_values({rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
+              "query": "label_values(process_cpu_seconds_total{job=\"central\", rhacs_org_name=~\"$org_name\", rhacs_org_id=~\"$org_id\"}, rhacs_instance_id)",
               "refId": "StandardVariableQuery"
             },
             "refresh": 1,
@@ -1057,13 +1057,13 @@ spec:
         ]
       },
       "time": {
-        "from": "now-7d",
+        "from": "now-24h",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "RHACS Dataplane - Cluster Metrics",
       "uid": "4032f3c17643119901e107a0a1786d5b9e4c9565",
-      "version": 3,
+      "version": 4,
       "weekStart": ""
     }


### PR DESCRIPTION
After seeing #48 and #46 in action, it seems that the dynamic variable query is a bit slow. This optimises the query by reducing the overall cardinality of the metrics query. In my tests that helped cut down the render time quite a bit. I also switched the default time range to `24h` for the cluster dashboard just in case.

Also add a missing `count by` in one of the widgets.