### PR TITLE
Make restarting alerts critical

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -30,13 +30,12 @@ spec:
             sop_url: "" # TODO: Add SOP
         - alert: RHACSCentralContainerFrequentlyRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{container="central"}[10m]) > 3
-          for: 5m
+            increase(kube_pod_container_status_restarts_total{container="central"}[30m]) > 3
           labels:
-            severity: warning
+            severity: critical
           annotations:
             summary: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
-            description: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 10 minutes."
+            description: "Central container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 30 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSCentralDatabasePersistentVolumeFillingUp
           expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim="stackrox-db"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="stackrox-db"} < 0.1
@@ -81,13 +80,12 @@ spec:
             sop_url: "" # TODO: Add SOP
         - alert: RHACSScannerContainerFrequentlyRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{pod=~"scanner.*", container=~"scanner|db"}[10m]) > 3
-          for: 5m
+            increase(kube_pod_container_status_restarts_total{pod=~"scanner.*", container=~"scanner|db"}[30m]) > 3
           labels:
-            severity: warning
+            severity: critical
           annotations:
             summary: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
-            description: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 10 minutes."
+            description: "Scanner container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 30 minutes."
             sop_url: "" # TODO: Add SOP
 
     - name: rhacs-fleetshard
@@ -104,13 +102,12 @@ spec:
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardOperatorContainerFrequentlyRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{pod=~"rhacs-operator-controller-manager-.*"}[60m]) > 3
-          for: 5m
+            increase(kube_pod_container_status_restarts_total{pod=~"rhacs-operator-controller-manager-.*"}[30m]) > 3
           labels:
-            severity: warning
+            severity: critical
           annotations:
             summary: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
-            description: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 60 minutes."
+            description: "Fleetshard operator container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 30 minutes."
             sop_url: "" # TODO: Add SOP
 
         - alert: RHACSFleetshardSyncScrapeFailed
@@ -134,12 +131,12 @@ spec:
             description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 10 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardSyncContainerFrequentlyRestarting
-          expr: increase(kube_pod_container_status_restarts_total{pod=~"fleetshard-sync-.*"}[60m]) > 3
+          expr: increase(kube_pod_container_status_restarts_total{pod=~"fleetshard-sync-.*"}[30m]) > 3
           labels:
-            severity: warning
+            severity: critical
           annotations:
             summary: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
-            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 60 minutes."
+            description: "Fleetshard synchronizer container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 30 minutes."
             sop_url: "" # TODO: Add SOP
         - alert: RHACSFleetshardSyncReconciliationErrors
           expr: |

--- a/resources/prometheus/unit_tests/RHACSCentralContainerFrequentlyRestarting.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralContainerFrequentlyRestarting.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_pod_container_status_restarts_total{namespace="rhacs-1234", pod="central-1234-5678", container="central"}
-        values: "0+0x5 1+1x10 4+1x10"
+        values: "0+0x10 1+1x10 4+1x20"
     alert_rule_test:
       - eval_time: 10m
         alertname: RHACSCentralContainerFrequentlyRestarting
         exp_alerts: []
-      - eval_time: 20m
+      - eval_time: 30m
         alertname: RHACSCentralContainerFrequentlyRestarting
         exp_alerts:
           - exp_labels:
@@ -20,8 +20,8 @@ tests:
               container: central
               namespace: rhacs-1234
               pod: central-1234-5678
-              severity: warning
+              severity: critical
             exp_annotations:
               summary: "Central container `central-1234-5678/central` in namespace `rhacs-1234` restarted more than 3 times."
-              description: "Central container `central-1234-5678/central` in namespace `rhacs-1234` has restarted more than 3 times during the last 10 minutes."
+              description: "Central container `central-1234-5678/central` in namespace `rhacs-1234` has restarted more than 3 times during the last 30 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardOperatorContainerFrequentlyRestarting.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardOperatorContainerFrequentlyRestarting.yaml
@@ -7,9 +7,9 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_pod_container_status_restarts_total{namespace="rhacs", pod="rhacs-operator-controller-manager-1234", container="manager"}
-        values: "0+0x30 1+1x10 4+1x10"
+        values: "0+0x30 1+1x10 4+1x20"
       - series: kube_pod_container_status_restarts_total{namespace="rhacs", pod="rhacs-operator-controller-manager-1234", container="kube-rbac-proxy"}
-        values: "0+0x30 1+1x10 4+1x10"
+        values: "0+0x30 1+1x10 4+1x20"
     alert_rule_test:
       - eval_time: 30m
         alertname: RHACSFleetshardOperatorContainerFrequentlyRestarting
@@ -22,18 +22,18 @@ tests:
               container: manager
               namespace: rhacs
               pod: rhacs-operator-controller-manager-1234
-              severity: warning
+              severity: critical
             exp_annotations:
               summary: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` restarted more than 3 times."
-              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` has restarted more than 3 times during the last 60 minutes."
+              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/manager` in namespace `rhacs` has restarted more than 3 times during the last 30 minutes."
               sop_url: ""
           - exp_labels:
               alertname: RHACSFleetshardOperatorContainerFrequentlyRestarting
               container: kube-rbac-proxy
               namespace: rhacs
               pod: rhacs-operator-controller-manager-1234
-              severity: warning
+              severity: critical
             exp_annotations:
               summary: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` restarted more than 3 times."
-              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` has restarted more than 3 times during the last 60 minutes."
+              description: "Fleetshard operator container `rhacs-operator-controller-manager-1234/kube-rbac-proxy` in namespace `rhacs` has restarted more than 3 times during the last 30 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncContainerFrequentlyRestarting.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncContainerFrequentlyRestarting.yaml
@@ -7,7 +7,7 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_pod_container_status_restarts_total{namespace="rhacs", pod="fleetshard-sync-1234", container="fleetshard-sync"}
-        values: "0+0x30 1+1x10 4+1x10"
+        values: "0+0x30 1+1x10 4+1x20"
     alert_rule_test:
       - eval_time: 30m
         alertname: RHACSFleetshardSyncContainerFrequentlyRestarting
@@ -20,8 +20,8 @@ tests:
               container: fleetshard-sync
               namespace: rhacs
               pod: fleetshard-sync-1234
-              severity: warning
+              severity: critical
             exp_annotations:
               summary: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` restarted more than 3 times."
-              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has restarted more than 3 times during the last 60 minutes."
+              description: "Fleetshard synchronizer container `fleetshard-sync-1234/fleetshard-sync` in namespace `rhacs` has restarted more than 3 times during the last 30 minutes."
               sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSScannerContainerFrequentlyRestarting.yaml
+++ b/resources/prometheus/unit_tests/RHACSScannerContainerFrequentlyRestarting.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_pod_container_status_restarts_total{namespace="rhacs-1234", pod="scanner-1234-5678", container="scanner"}
-        values: "0+0x5 1+1x10 4+1x10"
+        values: "0+0x10 1+1x10 4+1x20"
     alert_rule_test:
       - eval_time: 10m
         alertname: RHACSScannerContainerFrequentlyRestarting
         exp_alerts: []
-      - eval_time: 20m
+      - eval_time: 30m
         alertname: RHACSScannerContainerFrequentlyRestarting
         exp_alerts:
           - exp_labels:
@@ -20,8 +20,8 @@ tests:
               container: scanner
               namespace: rhacs-1234
               pod: scanner-1234-5678
-              severity: warning
+              severity: critical
             exp_annotations:
               summary: "Scanner container `scanner-1234-5678/scanner` in namespace `rhacs-1234` restarted more than 3 times."
-              description: "Scanner container `scanner-1234-5678/scanner` in namespace `rhacs-1234` has restarted more than 3 times during the last 10 minutes."
+              description: "Scanner container `scanner-1234-5678/scanner` in namespace `rhacs-1234` has restarted more than 3 times during the last 30 minutes."
               sop_url: ""


### PR DESCRIPTION
* Raise severity of restart alerts to `critical`. These alerts are an indicator of Central OOM-ing repeatedly.
* Count restarts over 30 mins to give more time in case Central's are alive for more than a few minutes at a time.