### PR TITLE
Rename `kafka-prometheus` -> `obs-prometheus`

### DIFF
--- a/resources/prometheus/pod_monitors/prometheus-self-metrics.yaml
+++ b/resources/prometheus/pod_monitors/prometheus-self-metrics.yaml
@@ -12,4 +12,4 @@ spec:
       port: web
   selector:
     matchLabels:
-      prometheus: kafka-prometheus
+      prometheus: obs-prometheus

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -210,7 +210,7 @@ spec:
     - name: observability-operator
       rules:
         - alert: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
-          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-kafka-prometheus-[0-9]"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"managed-services-prometheus-kafka-prometheus-[0-9]"} < 0.1
+          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-obs-prometheus-[0-9]"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"managed-services-prometheus-obs-prometheus-[0-9]"} < 0.1
           for: 5m
           labels:
             severity: critical
@@ -220,7 +220,7 @@ spec:
             sop_url: "" # TODO: Add SOP
 
         - alert: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
-          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-kafka-prometheus-[0-9]"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"managed-services-prometheus-kafka-prometheus-[0-9]"} < 0.25 and predict_linear(kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-kafka-prometheus-[0-9]"}[6h], 4 * 24 * 3600) < 0
+          expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-obs-prometheus-[0-9]"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"managed-services-prometheus-obs-prometheus-[0-9]"} < 0.25 and predict_linear(kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"managed-services-prometheus-obs-prometheus-[0-9]"}[6h], 4 * 24 * 3600) < 0
           for: 5m
           labels:
             severity: warning

--- a/resources/prometheus/unit_tests/ObservabilityOperatorPrometheusPersistentVolumeFillingUp.yaml
+++ b/resources/prometheus/unit_tests/ObservabilityOperatorPrometheusPersistentVolumeFillingUp.yaml
@@ -6,10 +6,10 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: kubelet_volume_stats_available_bytes{persistentvolumeclaim="managed-services-prometheus-kafka-prometheus-0", namespace="rhacs-observability"}
+      - series: kubelet_volume_stats_available_bytes{persistentvolumeclaim="managed-services-prometheus-obs-prometheus-0", namespace="rhacs-observability"}
         # Initial time series value is 10GiB, it is decremented by 100MiB every minute for 360 minutes.
         values: "10737418240+0x10 10737418240-104857600x110"
-      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="managed-services-prometheus-kafka-prometheus-0", namespace="rhacs-observability"}
+      - series: kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="managed-services-prometheus-obs-prometheus-0", namespace="rhacs-observability"}
         values: "10737418240+0x120"
     alert_rule_test:
       - eval_time: 10m
@@ -21,11 +21,11 @@ tests:
           - exp_labels:
               alertname: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
               severity: warning
-              persistentvolumeclaim: managed-services-prometheus-kafka-prometheus-0
+              persistentvolumeclaim: managed-services-prometheus-obs-prometheus-0
               namespace: rhacs-observability
             exp_annotations:
               summary: "The Observability Operator's Prometheus persistent volume in namespace namespace `rhacs-observability` is filling up."
-              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-kafka-prometheus-0`. Available storage quota is `13.09%`. The volume is expected to fill up within 4 days based on linear extrapolation over the last 6 hours."
+              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-obs-prometheus-0`. Available storage quota is `13.09%`. The volume is expected to fill up within 4 days based on linear extrapolation over the last 6 hours."
               sop_url: ""
       - eval_time: 110m
         alertname: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
@@ -33,18 +33,18 @@ tests:
           - exp_labels:
               alertname: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
               severity: critical
-              persistentvolumeclaim: managed-services-prometheus-kafka-prometheus-0
+              persistentvolumeclaim: managed-services-prometheus-obs-prometheus-0
               namespace: rhacs-observability
             exp_annotations:
               summary: "The Observability Operator's Prometheus persistent volume in namespace namespace `rhacs-observability` is filling up."
-              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-kafka-prometheus-0`. Available storage quota is `3.32%`."
+              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-obs-prometheus-0`. Available storage quota is `3.32%`."
               sop_url: ""
           - exp_labels:
               alertname: ObservabilityOperatorPrometheusPersistentVolumeFillingUp
               severity: warning
-              persistentvolumeclaim: managed-services-prometheus-kafka-prometheus-0
+              persistentvolumeclaim: managed-services-prometheus-obs-prometheus-0
               namespace: rhacs-observability
             exp_annotations:
               summary: "The Observability Operator's Prometheus persistent volume in namespace namespace `rhacs-observability` is filling up."
-              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-kafka-prometheus-0`. Available storage quota is `3.32%`. The volume is expected to fill up within 4 days based on linear extrapolation over the last 6 hours."
+              description: "The Observability Operator's Prometheus storage in namespace `rhacs-observability` is filling up for PVC `managed-services-prometheus-obs-prometheus-0`. Available storage quota is `3.32%`. The volume is expected to fill up within 4 days based on linear extrapolation over the last 6 hours."
               sop_url: ""


### PR DESCRIPTION
The default resource name has been changed in observability operator version `>=v4.0`.

See also https://github.com/stackrox/acs-fleet-manager/pull/786.

Note that the resource names have already been changed on stage due to the above PR (despite my assumption to the contrary).