### PR TITLE
ROX-14270: Add cloudwatch exporter pod monitor

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -5,6 +5,7 @@
       "pod_monitors": [
         "prometheus/pod_monitors/prometheus-self-metrics.yaml",
         "prometheus/pod_monitors/rhacs-central-metrics.yaml",
+        "prometheus/pod_monitors/rhacs-cloudwatch-exporter.yaml",
         "prometheus/pod_monitors/rhacs-fleetshard-sync-metrics.yaml",
         "prometheus/pod_monitors/rhacs-probe-metrics.yaml",
         "prometheus/pod_monitors/rhacs-scanner-metrics.yaml"

--- a/resources/prometheus/pod_monitors/rhacs-cloudwatch-exporter.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-cloudwatch-exporter.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: rhacs-cloudwatch-metrics
+  labels:
+    app: strimzi
+spec:
+  selector:
+    matchLabels:
+      app: cloudwatch-exporter
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+    - path: /metrics
+      port: monitoring
+      relabelings:
+        - action: labeldrop
+          regex: endpoint
+
+        - sourceLabels: [container]
+          action: replace
+          targetLabel: job


### PR DESCRIPTION
Add a pod monitor to scrape the cloudwatch exporter. The exporter is used to scrape RDS database metrics from AWS.

See https://github.com/stackrox/acs-fleet-manager/pull/801 for the cloudwatch exporter deployment.