### PR TITLE
ROX-14416: RHACSCentralPostgresConnectionDown alert

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -55,6 +55,15 @@ spec:
             summary: "Central database storage in namespace `{{ $labels.namespace }}` is filing up."
             description: "Central database storage in namespace `{{ $labels.namespace }}` is filling up for PVC `{{ $labels.persistentvolumeclaim }}`. Available storage quota is `{{ $value | humanizePercentage }}`. The volume is expected to fill up within 4 days based on linear extrapolation over the last 6 hours."
             sop_url: "" # TODO: Add SOP
+        - alert: RHACSCentralPostgresConnectionDown
+          expr: avg_over_time(rox_central_postgres_connected{container="central"}[10m]) < 0.5
+          for: 20m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Central container `{{ $labels.pod }}/{{ $labels.container }}` database connection in namespace `{{ $labels.namespace }}` is down or is in a bad shape."
+            description: "Central container `{{ $labels.pod }}/{{ $labels.container }}` database connection in namespace `{{ $labels.namespace }}` has been down or is in a bad shape for at least 10 minutes."
+            sop_url: "" # TODO: Add SOP
 
     - name: rhacs-scanner
       rules:

--- a/resources/prometheus/unit_tests/RHACSCentralPostgresConnectionDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralPostgresConnectionDown.yaml
@@ -1,0 +1,27 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: rox_central_postgres_connected{namespace="rhacs-1234", pod="central-1234", container="central"}
+        values: "1+0x10 0+0x50"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RHACSCentralPostgresConnectionDown
+        exp_alerts: []
+      - eval_time: 40m
+        alertname: RHACSCentralPostgresConnectionDown
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSCentralPostgresConnectionDown
+              pod: central-1234
+              container: central
+              namespace: rhacs-1234
+              severity: critical
+            exp_annotations:
+              summary: "Central container `central-1234/central` database connection in namespace `rhacs-1234` is down or is in a bad shape."
+              description: "Central container `central-1234/central` database connection in namespace `rhacs-1234` has been down or is in a bad shape for at least 10 minutes."
+              sop_url: ""


### PR DESCRIPTION
```
# ./scripts/test-prom-rules.sh
...
/home/mipetrov/go/src/github.com/stackrox/rhacs-observability-resources/scripts/../resources/prometheus/unit_tests/RHACSCentralPostgresConnectionDown.yaml
Unit Testing:  /home/mipetrov/go/src/github.com/stackrox/rhacs-observability-resources/scripts/../resources/prometheus/unit_tests/RHACSCentralPostgresConnectionDown.yaml
  SUCCESS
```