### PR TITLE
add alerts for failing probe pods

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -189,6 +189,35 @@ spec:
             summary: "The latest probe run failed at `{{ $value | humanizeTimestamp }}`."
             description: "The latest run of probe `{{ $labels.pod }}` failed at `{{ $value | humanizeTimestamp }}`."
             sop_url: "" # TODO: Add SOP ([ROX-11888](https://issues.redhat.com/browse/ROX-11888]))
+        - alert: RHACSProbeScrapeFailed
+          expr: |
+            avg_over_time(up{job="probe"}[10m]) < 0.5 and ON(pod) kube_pod_container_status_ready{container="probe"} == 1
+          for: 20m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Prometheus unable to scrape metrics from target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}`."
+            description: "During the last 10 minutes, only `{{ $value | humanizePercentage }}` of scrapes of target `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` were successful. This alert is raised when less than 50% of scrapes are successful."
+            sop_url: "" # TODO: Add SOP
+        - alert: RHACSProbeContainerDown
+          expr: |
+            avg_over_time(kube_pod_container_status_ready{container="probe"}[10m]) < 0.5
+          for: 20m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Probe container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` is down or in a CrashLoopBackOff status."
+            description: "Probe container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has been down or in a CrashLoopBackOff status for at least 10 minutes."
+            sop_url: "" # TODO: Add SOP
+        - alert: RHACSProbeContainerFrequentlyRestarting
+          expr: |
+            increase(kube_pod_container_status_restarts_total{container="probe"}[30m]) > 3
+          labels:
+            severity: critical
+          annotations:
+            summary: "Probe container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` restarted more than 3 times."
+            description: "Probe container `{{ $labels.pod }}/{{ $labels.container }}` in namespace `{{ $labels.namespace }}` has restarted more than 3 times during the last 30 minutes."
+            sop_url: "" # TODO: Add SOP
 
     - name: deadmanssnitch
       rules:

--- a/resources/prometheus/unit_tests/RHACSProbeContainerDown.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeContainerDown.yaml
@@ -1,0 +1,27 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: kube_pod_container_status_ready{namespace="rhacs-1234", pod="probe-1234", container="probe"}
+        values: "1+0x10 0+0x50"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: RHACSProbeContainerDown
+        exp_alerts: []
+      - eval_time: 40m
+        alertname: RHACSProbeContainerDown
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSProbeContainerDown
+              pod: probe-1234
+              container: probe
+              namespace: rhacs-1234
+              severity: critical
+            exp_annotations:
+              summary: "Probe container `probe-1234/probe` in namespace `rhacs-1234` is down or in a CrashLoopBackOff status."
+              description: "Probe container `probe-1234/probe` in namespace `rhacs-1234` has been down or in a CrashLoopBackOff status for at least 10 minutes."
+              sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSProbeContainerFrequentlyRestarting.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeContainerFrequentlyRestarting.yaml
@@ -1,0 +1,27 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: kube_pod_container_status_restarts_total{namespace="rhacs-1234", pod="probe-1234-5678", container="probe"}
+        values: "0+0x10 1+1x10 4+1x20"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RHACSProbeContainerFrequentlyRestarting
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: RHACSProbeContainerFrequentlyRestarting
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSProbeContainerFrequentlyRestarting
+              container: probe
+              namespace: rhacs-1234
+              pod: probe-1234-5678
+              severity: critical
+            exp_annotations:
+              summary: "Probe container `probe-1234-5678/probe` in namespace `rhacs-1234` restarted more than 3 times."
+              description: "Probe container `probe-1234-5678/probe` in namespace `rhacs-1234` has restarted more than 3 times during the last 30 minutes."
+              sop_url: ""

--- a/resources/prometheus/unit_tests/RHACSProbeScrapeFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeScrapeFailed.yaml
@@ -1,0 +1,30 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: up{namespace="rhacs-1234", pod="probe-1234-5678", job="probe", instance="1.2.3.4:9090"}
+        values: "0+0x20 1+0x20"
+      - series: kube_pod_container_status_ready{namespace="rhacs-1234", pod="probe-1234-5678", container="probe"}
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RHACSProbeScrapeFailed
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: RHACSProbeScrapeFailed
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSProbeScrapeFailed
+              instance: 1.2.3.4:9090
+              namespace: rhacs-1234
+              pod: probe-1234-5678
+              severity: critical
+              job: probe
+            exp_annotations:
+              summary: "Prometheus unable to scrape metrics from target `probe-1234-5678` in namespace `rhacs-1234`."
+              description: "During the last 10 minutes, only `45.45%` of scrapes of target `probe-1234-5678` in namespace `rhacs-1234` were successful. This alert is raised when less than 50% of scrapes are successful."
+              sop_url: ""


### PR DESCRIPTION
Currently we don't have alerts for the probe container itself. This is a problem if the probe is crashing, for example due to a missing image in the registry.