### PR TITLE
ROX-14416: High ACUUtilization alert

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -283,7 +283,7 @@ spec:
         - alert: AWSRDSACUUtilization
           expr: |
             avg_over_time(aws_rds_acuutilization_maximum[5m]) > 95
-          for: 10m
+          for: 1h
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/unit_tests/AWSRDSACUUtilization.yaml
+++ b/resources/prometheus/unit_tests/AWSRDSACUUtilization.yaml
@@ -7,12 +7,12 @@ tests:
   - interval: 1m
     input_series:
       - series: aws_rds_acuutilization_maximum{namespace="rhacs-1234", pod="scanner-1234-5678", instance="1.2.3.4:9090", dbinstance_identifier="test-db-instance"}
-        values: "50x5 100x20"
+        values: "50x10 100x70"
     alert_rule_test:
       - eval_time: 10m
         alertname: AWSRDSACUUtilization
         exp_alerts: []
-      - eval_time: 21m
+      - eval_time: 85m
         alertname: AWSRDSACUUtilization
         exp_alerts:
           - exp_labels:


### PR DESCRIPTION
Alert for `aws_rds_acuutilization_maximum` metric: fires if the metric is >95% for 10 minutes. This should not fire for short peaks, like for when probe clusters are being created.