### PR TITLE
Revert "ROX-10918: Use rhacs as selector label"

### DIFF
--- a/resources/grafana/mixins/kubernetes/apiserver.yaml
+++ b/resources/grafana/mixins/kubernetes/apiserver.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-apiserver
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/cluster-total.yaml
+++ b/resources/grafana/mixins/kubernetes/cluster-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-cluster-total
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/controller-manager.yaml
+++ b/resources/grafana/mixins/kubernetes/controller-manager.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-controller-manager
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-cluster
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-namespace
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-node
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-pod
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-workload
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-workloads-namespace
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/kubelet.yaml
+++ b/resources/grafana/mixins/kubernetes/kubelet.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-kubelet
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/namespace-by-pod.yaml
+++ b/resources/grafana/mixins/kubernetes/namespace-by-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-namespace-by-pod
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/namespace-by-workload.yaml
+++ b/resources/grafana/mixins/kubernetes/namespace-by-workload.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-namespace-by-workload
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/persistentvolumesusage.yaml
+++ b/resources/grafana/mixins/kubernetes/persistentvolumesusage.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-persistentvolumesusage
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/pod-total.yaml
+++ b/resources/grafana/mixins/kubernetes/pod-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-pod-total
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/proxy.yaml
+++ b/resources/grafana/mixins/kubernetes/proxy.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-proxy
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/scheduler.yaml
+++ b/resources/grafana/mixins/kubernetes/scheduler.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-scheduler
   namespace: <namespace>

--- a/resources/grafana/mixins/kubernetes/workload-total.yaml
+++ b/resources/grafana/mixins/kubernetes/workload-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-workload-total
   namespace: <namespace>

--- a/resources/grafana/rhacs-central-dashboard.yaml
+++ b/resources/grafana/rhacs-central-dashboard.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: rhacs-central-dashboard
   namespace: <namespace>

--- a/resources/grafana/rhacs-cluster-overview-dashboard.yaml
+++ b/resources/grafana/rhacs-cluster-overview-dashboard.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: rhacs-cluster-overview-dashboard
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/alerts.yaml
+++ b/resources/mixins/kubernetes/templates/alerts.yaml
@@ -2,6 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: kubernetes-mixin-alerts
 spec:

--- a/resources/mixins/kubernetes/templates/dashboards/apiserver.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/apiserver.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-apiserver
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/cluster-total.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/cluster-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-cluster-total
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/controller-manager.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/controller-manager.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-controller-manager
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-cluster.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-cluster
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-namespace.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-namespace
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-node.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-node.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-node
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-pod.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-pod
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-workload.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-workload.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-workload
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/k8s-resources-workloads-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-k8s-resources-workloads-namespace
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/kubelet.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/kubelet.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-kubelet
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/namespace-by-pod.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/namespace-by-pod.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-namespace-by-pod
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/namespace-by-workload.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/namespace-by-workload.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-namespace-by-workload
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/persistentvolumesusage.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/persistentvolumesusage.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-persistentvolumesusage
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/pod-total.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/pod-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-pod-total
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/proxy.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/proxy.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-proxy
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/scheduler.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/scheduler.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-scheduler
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/dashboards/workload-total.yaml
+++ b/resources/mixins/kubernetes/templates/dashboards/workload-total.yaml
@@ -2,7 +2,7 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
     monitoring-key: middleware
   name: kubernetes-mixin-workload-total
   namespace: <namespace>

--- a/resources/mixins/kubernetes/templates/rules.yaml
+++ b/resources/mixins/kubernetes/templates/rules.yaml
@@ -2,6 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: kubernetes-mixin-rules
 spec:

--- a/resources/prometheus/billing-rules.yaml
+++ b/resources/prometheus/billing-rules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: rhacs-billing-rules
 spec:
   groups:

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: kubernetes-mixin-alerts
 spec:
   "groups":

--- a/resources/prometheus/kubernetes-mixin-rules.yaml
+++ b/resources/prometheus/kubernetes-mixin-rules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: kubernetes-mixin-rules
 spec:
   "groups":

--- a/resources/prometheus/pod_monitors/prometheus-self-metrics.yaml
+++ b/resources/prometheus/pod_monitors/prometheus-self-metrics.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: prometheus-self-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   namespaceSelector:
     any: true

--- a/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-central-metrics.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: rhacs-central-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   selector:
     matchLabels:

--- a/resources/prometheus/pod_monitors/rhacs-cloudwatch-exporter.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-cloudwatch-exporter.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: rhacs-cloudwatch-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   selector:
     matchLabels:

--- a/resources/prometheus/pod_monitors/rhacs-fleetshard-sync-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-fleetshard-sync-metrics.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: rhacs-fleetshard-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   selector:
     matchLabels:

--- a/resources/prometheus/pod_monitors/rhacs-probe-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-probe-metrics.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: rhacs-probe-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   selector:
     matchLabels:

--- a/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
+++ b/resources/prometheus/pod_monitors/rhacs-scanner-metrics.yaml
@@ -3,7 +3,7 @@ kind: PodMonitor
 metadata:
   name: rhacs-scanner-metrics
   labels:
-    app: rhacs
+    app: strimzi
 spec:
   selector:
     matchLabels:

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: rhacs-data-plane-prometheus-rules
 spec:
   groups:

--- a/resources/prometheus/rhacs-recording-rules.yaml
+++ b/resources/prometheus/rhacs-recording-rules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app: rhacs
+    app: strimzi
   name: rhacs-recording-rules
 spec:
   groups:


### PR DESCRIPTION
This reverts commit c38541d406f069aebb5641915c7dfb62a32f44c4.

Sadly we have to revert the renaming for the time being. I realized that there are still label selectors - namely Prometheus rule selectors - that default to `strimzi`. I'll change these to `rhacs` via the observability operator CR in https://github.com/stackrox/acs-fleet-manager/pull/885, but since we just did a fleetshard-sync release, I'd rather revert this so we are free to sync with prod. I'll re-merge this change after all label selectors have been moved to `rhacs` after the next prod release.