### PR TITLE
update grafana version to 9.4.7

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -48,7 +48,7 @@
         "grafana/rhacs-central-dashboard.yaml",
         "grafana/rhacs-cluster-overview-dashboard.yaml"
       ],
-      "grafanaVersion": "9.1.0"
+      "grafanaVersion": "9.4.7"
     },
     "promtail": {
       "enabled": false,


### PR DESCRIPTION
Some general improvements and an improved search and navigation of recent dashboards. See https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-4/ for full changelog.