### PR TITLE
ROX-16887: ignore first 5m of pod life

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -298,7 +298,7 @@ spec:
         # Central pod must be ready to count as available.
         # This is a time series of 0s (down) and 1s (up).
         - expr: |
-            clamp_max(sum by(namespace) (kube_pod_container_status_ready{container="central", pod=~"central-.*", namespace=~"rhacs-.*"}), 1)
+            clamp_max(sum by(namespace) (kube_pod_container_status_ready{container="central", pod=~"central-.*", namespace=~"rhacs-.*"} offset -5m), 1)
           record: central:sli:pod_ready
 
         # Error rate SLI

--- a/resources/prometheus/unit_tests/RHACSCentralSLISLO.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralSLISLO.yaml
@@ -40,7 +40,7 @@ tests:
               namespace: rhacs-test1
               rhacs_instance_id: test
             exp_annotations:
-              message: "High availability error budget exhaustion for central. Current exhaustion: 100.2%."
+              message: "High availability error budget exhaustion for central. Current exhaustion: 100%."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
 
   # Central availability error budget exhaustion - 70%
@@ -73,7 +73,7 @@ tests:
               severity: warning
               namespace: rhacs-test2
             exp_annotations:
-              message: "High availability error budget exhaustion for central. Current exhaustion: 75.15%."
+              message: "High availability error budget exhaustion for central. Current exhaustion: 75%."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
 
   # Central availability error budget exhaustion - 50%
@@ -106,7 +106,7 @@ tests:
               severity: warning
               namespace: rhacs-test3
             exp_annotations:
-              message: "High availability error budget exhaustion for central. Current exhaustion: 50.1%."
+              message: "High availability error budget exhaustion for central. Current exhaustion: 50%."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
 
   # Central high availability burn rate
@@ -134,5 +134,5 @@ tests:
               severity: critical
               namespace: rhacs-test4
             exp_annotations:
-              message: "High availability burn rate for central. Current burn rate per hour: 59.02."
+              message: "High availability burn rate for central. Current burn rate per hour: 58.33."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"


### PR DESCRIPTION
Ignore first 5 minutes of the centrals pod ready metric so that we don't count the startup non-ready time in SLO.

Correction after #76.