### PR TITLE
make acu alert more resilient against spikes

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -281,8 +281,8 @@ spec:
       rules:
         - alert: AWSRDSACUUtilization
           expr: |
-            avg_over_time(aws_rds_acuutilization_maximum[5m]) > 95
-          for: 1h
+            aws_rds_acuutilization_average{dimension_DBInstanceIdentifier=~"rhacs-.*"} > 95
+          for: 15m
           labels:
             severity: critical
           annotations:

--- a/resources/prometheus/unit_tests/AWSRDSACUUtilization.yaml
+++ b/resources/prometheus/unit_tests/AWSRDSACUUtilization.yaml
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: aws_rds_acuutilization_maximum{namespace="rhacs-1234", pod="scanner-1234-5678", instance="1.2.3.4:9090", dimension_DBInstanceIdentifier="test-db-instance"}
+      - series: aws_rds_acuutilization_average{namespace="rhacs-1234", dimension_DBInstanceIdentifier="rhacs-test-db-instance"}
         values: "50x10 100x70"
     alert_rule_test:
       - eval_time: 10m
@@ -17,14 +17,12 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: AWSRDSACUUtilization
-              dimension_DBInstanceIdentifier: test-db-instance
-              instance: 1.2.3.4:9090
+              dimension_DBInstanceIdentifier: rhacs-test-db-instance
               namespace: rhacs-1234
-              pod: scanner-1234-5678
               severity: critical
             exp_annotations:
-              summary: "The AWS RDS ACUUtilization for `test-db-instance` DB instance is too high."
+              summary: "The AWS RDS ACUUtilization for `rhacs-test-db-instance` DB instance is too high."
               description: >
-                The DB instance `test-db-instance` has scaled up as high as it can.
+                The DB instance `rhacs-test-db-instance` has scaled up as high as it can.
                 Consider increasing the maximum ACU setting for the cluster.
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-014-aws-rds-acu-utilization.md"


### PR DESCRIPTION
* Remove the `avg_over_time` because AWS already aggregates metrics over a five minute interval.
* Switch the alert from `_maximum` to `_average` to be more resilient against temporary ACU spikes. 
* Add a filter based on the instance DB label. This is currently redundant, but just in case we ever export other ACU metrics in the future - for example total cluster ACU.