### PR TITLE
ROX-17093: only count server error codes in grpc SLI

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -307,8 +307,8 @@ spec:
         # GRPC
         - expr: |
             sum by (namespace, rhacs_instance_id, rhacs_org_id, rhacs_org_name, rhacs_cluster_name, rhacs_environment)
-            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_code="OK"}[10m]))
-          record: central:grpc_server_handled:OK:rate10m
+            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_code!~"DataLoss|DeadlineExceeded|Internal|Unavailable|Unknown"}[10m]))
+          record: central:grpc_server_handled:not_server_error:rate10m
 
         - expr: |
             sum by (namespace, rhacs_instance_id, rhacs_org_id, rhacs_org_name, rhacs_cluster_name, rhacs_environment)
@@ -332,7 +332,7 @@ spec:
         - expr: |
             floor(
               (
-                central:grpc_server_handled:OK:rate10m
+                central:grpc_server_handled:not_server_error:rate10m
               + central:http_incoming_requests:not_5xx:rate10m
               ) / (
                 central:grpc_server_started:total:rate10m

--- a/resources/prometheus/unit_tests/RHACSCentralSLISLO.yaml
+++ b/resources/prometheus/unit_tests/RHACSCentralSLISLO.yaml
@@ -21,8 +21,8 @@ tests:
         values: "1+1x360 362+2x40"
       - series: http_incoming_requests_total{job="central", code="200", namespace="rhacs-test1", rhacs_instance_id="test"}
         values: "4+4x400"
-      # 200m downtime due NOK or 5xx responses. Out of 28 days, this equates to ~0.5% downtime.
-      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="NOK", namespace="rhacs-test1", rhacs_instance_id="test"}
+      # 200m downtime due Unavailable or 5xx responses. Out of 28 days, this equates to ~0.5% downtime.
+      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="Unavailable", namespace="rhacs-test1", rhacs_instance_id="test"}
         values: "0+0x360 0+1x40"
       - series: http_incoming_requests_total{job="central", code="500", namespace="rhacs-test1", rhacs_instance_id="test"}
         values: "0+0x360 0+4x40"
@@ -55,8 +55,8 @@ tests:
         values: "1+1x365 367+2x35"
       - series: http_incoming_requests_total{job="central", code="200", namespace="rhacs-test2", rhacs_instance_id="test"}
         values: "4+4x400"
-      # 175m downtime due NOK or 5xx responses. Out of 28 days, this equates to ~0.43% downtime.
-      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="NOK", namespace="rhacs-test2", rhacs_instance_id="test"}
+      # 175m downtime due Unavailable or 5xx responses. Out of 28 days, this equates to ~0.43% downtime.
+      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="Unavailable", namespace="rhacs-test2", rhacs_instance_id="test"}
         values: "0+0x365 0+1x35"
       - series: http_incoming_requests_total{job="central", code="500", namespace="rhacs-test2", rhacs_instance_id="test"}
         values: "0+0x365 0+4x35"
@@ -89,8 +89,8 @@ tests:
         values: "1+1x379 381+2x21"
       - series: http_incoming_requests_total{job="central", code="200", namespace="rhacs-test3", rhacs_instance_id="test"}
         values: "4+4x400"
-      # 105m downtime due NOK or 5xx responses. Out of 28 days, this equates to ~0.25% downtime.
-      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="NOK", namespace="rhacs-test3", rhacs_instance_id="test"}
+      # 105m downtime due Unavailable or 5xx responses. Out of 28 days, this equates to ~0.25% downtime.
+      - series: grpc_server_handled_total{job="central", grpc_type="unary", grpc_code="Unavailable", namespace="rhacs-test3", rhacs_instance_id="test"}
         values: "0+0x379 0+1x21"
       - series: http_incoming_requests_total{job="central", code="500", namespace="rhacs-test3", rhacs_instance_id="test"}
         values: "0+0x379 0+4x21"


### PR DESCRIPTION
We don't want to count client errors (4xx equivalents) into the error rate SLI. Furthermore, this change allows us to modify the behavior of Central when the Scanner semaphore limit is hit. In this case we currently return `grpc_code=Unavailable`, but we are thinking about changing the return code to `grpc_code=ResourceExhausted`. Expected retries due to the semaphore would then no longer count as unavailable.

See https://grpc.github.io/grpc/core/md_doc_statuscodes.html for a list of all grpc codes and their meaning.