### PR TITLE
Filter openshift namespaces from CPUThrottlingHigh alert

### DIFF
--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -358,7 +358,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
             "summary": "Processes experience elevated CPU throttling."
           "expr": |
-            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="",namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
               /
             sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
               > ( 25 / 100 )

--- a/resources/prometheus/unit_tests/CPUThrottlingHigh.yaml
+++ b/resources/prometheus/unit_tests/CPUThrottlingHigh.yaml
@@ -1,0 +1,34 @@
+rule_files:
+  - /tmp/kubernetes-mixin-alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: container_cpu_cfs_throttled_periods_total{container="test",pod="test-pod",namespace="test"}
+        values: "1+1x100"
+      - series: container_cpu_cfs_periods_total{container="test",pod="test-pod",namespace="test"}
+        values: "1+2x100"
+      - series: container_cpu_cfs_throttled_periods_total{container="openshift-test",pod="openshift-test-pod",namespace="openshift-test"}
+        values: "1+1x100"
+      - series: container_cpu_cfs_periods_total{container="openshift-test",pod="openshift-test-pod",namespace="openshift-test"}
+        values: "1+2x100"
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: CPUThrottlingHigh
+        exp_alerts: []
+      - eval_time: 20m
+        alertname: CPUThrottlingHigh
+        exp_alerts:
+          - exp_labels:
+              alertname: CPUThrottlingHigh
+              severity: info
+              source: mixin/kubernetes
+              container: test
+              pod: test-pod
+              namespace: test
+            exp_annotations:
+              description: "50% throttling of CPU in namespace test for container test in pod test-pod."
+              runbook_url: "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
+              summary: "Processes experience elevated CPU throttling."

--- a/scripts/test-prom-rules.sh
+++ b/scripts/test-prom-rules.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2
 
 yq eval '.spec' "${SCRIPT_DIR}"/../resources/prometheus/prometheus-rules.yaml >/tmp/prometheus-rules-test.yaml
 yq eval '.spec' "${SCRIPT_DIR}"/../resources/prometheus/rhacs-recording-rules.yaml >/tmp/recording-rules-test.yaml
+yq eval '.spec' "${SCRIPT_DIR}"/../resources/prometheus/kubernetes-mixin-alerts.yaml >/tmp/kubernetes-mixin-alerts.yaml
 for f in "${SCRIPT_DIR}"/../resources/prometheus/unit_tests/*; do
 	echo "$f"
 	promtool test rules "${f}"


### PR DESCRIPTION
Issues with CPU throttling on openshift namespaces are generally out of our control, and excluding these noisy namespaces will help our signal-to-noise ratio.