### PR TITLE
Generate kube-state alarms only for RHACS namespace

### DIFF
--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -7,7 +7,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
       "summary": "Pod is crash looping."
     "expr": |
-      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
+      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m]) >= 1
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -20,7 +20,7 @@
     "expr": |
       sum by (namespace, pod, cluster) (
         max by(namespace, pod, cluster) (
-          kube_pod_status_phase{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+          kube_pod_status_phase{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
         ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
           1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
         )
@@ -35,9 +35,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
       "summary": "Deployment generation mismatch due to possible roll-back"
     "expr": |
-      kube_deployment_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         !=
-      kube_deployment_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -49,11 +49,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_deployment_spec_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_deployment_spec_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
           >
-        kube_deployment_status_replicas_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_deployment_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+        changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -67,7 +67,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
       "summary": "Deployment rollout is not progressing."
     "expr": |
-      kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
       != 0
     "for": "15m"
     "labels":
@@ -80,11 +80,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_statefulset_status_replicas_ready{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
           !=
-        kube_statefulset_status_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -98,9 +98,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
       "summary": "StatefulSet generation mismatch due to possible roll-back"
     "expr": |
-      kube_statefulset_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         !=
-      kube_statefulset_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -113,18 +113,18 @@
     "expr": |
       (
         max without (revision) (
-          kube_statefulset_status_current_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
             unless
-          kube_statefulset_status_update_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         )
           *
         (
-          kube_statefulset_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
             !=
-          kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         )
       )  and (
-        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -140,24 +140,24 @@
     "expr": |
       (
         (
-          kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
            !=
           0
         ) or (
-          kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         )
       ) and (
-        changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+        changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -171,7 +171,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
       "summary": "Pod container waiting longer than 1 hour"
     "expr": |
-      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
+      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}) > 0
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -182,9 +182,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
       "summary": "DaemonSet pods are not scheduled."
     "expr": |
-      kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         -
-      kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
     "for": "10m"
     "labels":
       "severity": "warning"
@@ -195,7 +195,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
       "summary": "DaemonSet pods are misscheduled."
     "expr": |
-      kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -206,9 +206,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
       "summary": "Job did not complete in time"
     "expr": |
-      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         and
-      kube_job_status_active{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
+      kube_job_status_active{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0) > 43200
     "labels":
       "severity": "warning"
       "source": "mixin/kubernetes"
@@ -218,7 +218,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
       "summary": "Job failed to complete."
     "expr": |
-      kube_job_failed{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
+      kube_job_failed{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}  > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -229,19 +229,19 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
       "summary": "HPA has not matched desired number of replicas."
     "expr": |
-      (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         !=
-      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         >
-      kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         <
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
         and
-      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
+      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[15m]) == 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -252,9 +252,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
       "summary": "HPA is running at max replicas"
     "expr": |
-      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
         ==
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "info"
@@ -293,7 +293,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
       "summary": "Cluster has overcommitted CPU resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
         /
       sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
         > 1.5
@@ -307,7 +307,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
       "summary": "Cluster has overcommitted memory resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
         /
       sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
         > 1.5
@@ -321,9 +321,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
       "summary": "Namespace quota is going to be full."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
         > 0.9 < 1
     "for": "15m"
     "labels":
@@ -335,9 +335,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
       "summary": "Namespace quota is fully used."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
         == 1
     "for": "15m"
     "labels":
@@ -349,9 +349,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
       "summary": "Namespace quota has exceeded the limits."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
         > 1
     "for": "15m"
     "labels":
@@ -380,16 +380,16 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -401,18 +401,18 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -424,16 +424,16 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -445,18 +445,18 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -467,7 +467,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
       "summary": "PersistentVolume is having issues with provisioning."
     "expr": |
-      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
     "for": "5m"
     "labels":
       "severity": "critical"

--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -7,7 +7,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
       "summary": "Pod is crash looping."
     "expr": |
-      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", job="kube-state-metrics"}[5m]) >= 1
+      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -20,7 +20,7 @@
     "expr": |
       sum by (namespace, pod, cluster) (
         max by(namespace, pod, cluster) (
-          kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+          kube_pod_status_phase{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
         ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
           1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
         )
@@ -35,9 +35,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
       "summary": "Deployment generation mismatch due to possible roll-back"
     "expr": |
-      kube_deployment_status_observed_generation{job="kube-state-metrics"}
+      kube_deployment_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_deployment_metadata_generation{job="kube-state-metrics"}
+      kube_deployment_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -49,14 +49,26 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_deployment_spec_replicas{job="kube-state-metrics"}
+        kube_deployment_spec_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
           >
-        kube_deployment_status_replicas_available{job="kube-state-metrics"}
+        kube_deployment_status_replicas_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_deployment_status_replicas_updated{job="kube-state-metrics"}[10m])
+        changes(kube_deployment_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
+    "for": "15m"
+    "labels":
+      "severity": "warning"
+      "source": "mixin/kubernetes"
+  - "alert": "KubeDeploymentRolloutStuck"
+    "annotations":
+      "description": "Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 15 minutes."
+      "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
+      "summary": "Deployment rollout is not progressing."
+    "expr": |
+      kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      != 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -68,11 +80,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+        kube_statefulset_status_replicas_ready{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
           !=
-        kube_statefulset_status_replicas{job="kube-state-metrics"}
+        kube_statefulset_status_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[10m])
+        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -86,9 +98,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
       "summary": "StatefulSet generation mismatch due to possible roll-back"
     "expr": |
-      kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+      kube_statefulset_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_statefulset_metadata_generation{job="kube-state-metrics"}
+      kube_statefulset_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -101,18 +113,18 @@
     "expr": |
       (
         max without (revision) (
-          kube_statefulset_status_current_revision{job="kube-state-metrics"}
+          kube_statefulset_status_current_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
             unless
-          kube_statefulset_status_update_revision{job="kube-state-metrics"}
+          kube_statefulset_status_update_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
           *
         (
-          kube_statefulset_replicas{job="kube-state-metrics"}
+          kube_statefulset_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
             !=
-          kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+          kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
       )  and (
-        changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[5m])
+        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -128,24 +140,24 @@
     "expr": |
       (
         (
-          kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"}
+          kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+          kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
           0
         ) or (
-          kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}
+          kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_available{job="kube-state-metrics"}
+          kube_daemonset_status_number_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
       ) and (
-        changes(kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}[5m])
+        changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -159,7 +171,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
       "summary": "Pod container waiting longer than 1 hour"
     "expr": |
-      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"}) > 0
+      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -170,9 +182,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
       "summary": "DaemonSet pods are not scheduled."
     "expr": |
-      kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+      kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         -
-      kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+      kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "10m"
     "labels":
       "severity": "warning"
@@ -183,7 +195,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
       "summary": "DaemonSet pods are misscheduled."
     "expr": |
-      kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+      kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -194,9 +206,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
       "summary": "Job did not complete in time"
     "expr": |
-      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{job="kube-state-metrics"}
+      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         and
-      kube_job_status_active{job="kube-state-metrics"} > 0) > 43200
+      kube_job_status_active{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
     "labels":
       "severity": "warning"
       "source": "mixin/kubernetes"
@@ -206,7 +218,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
       "summary": "Job failed to complete."
     "expr": |
-      kube_job_failed{job="kube-state-metrics"}  > 0
+      kube_job_failed{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -217,19 +229,19 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
       "summary": "HPA has not matched desired number of replicas."
     "expr": |
-      (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         >
-      kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         <
-      kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      changes(kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}[15m]) == 0
+      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -240,9 +252,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
       "summary": "HPA is running at max replicas"
     "expr": |
-      kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ==
-      kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "info"
@@ -281,7 +293,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
       "summary": "Cluster has overcommitted CPU resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
         /
       sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
         > 1.5
@@ -295,7 +307,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
       "summary": "Cluster has overcommitted memory resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
         /
       sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
         > 1.5
@@ -309,9 +321,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
       "summary": "Namespace quota is going to be full."
     "expr": |
-      kube_resourcequota{job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         > 0.9 < 1
     "for": "15m"
     "labels":
@@ -323,9 +335,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
       "summary": "Namespace quota is fully used."
     "expr": |
-      kube_resourcequota{job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         == 1
     "for": "15m"
     "labels":
@@ -337,9 +349,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
       "summary": "Namespace quota has exceeded the limits."
     "expr": |
-      kube_resourcequota{job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         > 1
     "for": "15m"
     "labels":
@@ -368,16 +380,16 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_used_bytes{job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -389,18 +401,18 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_used_bytes{job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -412,16 +424,16 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{job="kubelet"}
+        kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_inodes_used{job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -433,18 +445,18 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{job="kubelet"}
+        kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_inodes_used{job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -455,7 +467,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
       "summary": "PersistentVolume is having issues with provisioning."
     "expr": |
-      kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "5m"
     "labels":
       "severity": "critical"
@@ -557,7 +569,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeaggregatedapierrors"
       "summary": "Kubernetes aggregated API has reported errors."
     "expr": |
-      sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+      sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="api"}[10m])) > 4
     "labels":
       "severity": "warning"
       "source": "mixin/kubernetes"
@@ -567,7 +579,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeaggregatedapidown"
       "summary": "Kubernetes aggregated API is down."
     "expr": |
-      (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+      (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice{job="api"}[10m]))) * 100 < 85
     "for": "5m"
     "labels":
       "severity": "warning"

--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -7,7 +7,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
       "summary": "Pod is crash looping."
     "expr": |
-      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
+      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -20,7 +20,7 @@
     "expr": |
       sum by (namespace, pod, cluster) (
         max by(namespace, pod, cluster) (
-          kube_pod_status_phase{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+          kube_pod_status_phase{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
         ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
           1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
         )
@@ -35,9 +35,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
       "summary": "Deployment generation mismatch due to possible roll-back"
     "expr": |
-      kube_deployment_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_deployment_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -49,11 +49,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_deployment_spec_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_deployment_spec_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
           >
-        kube_deployment_status_replicas_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_deployment_status_replicas_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_deployment_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+        changes(kube_deployment_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -67,7 +67,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
       "summary": "Deployment rollout is not progressing."
     "expr": |
-      kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
       != 0
     "for": "15m"
     "labels":
@@ -80,11 +80,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_statefulset_status_replicas_ready{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas_ready{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
           !=
-        kube_statefulset_status_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -98,9 +98,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
       "summary": "StatefulSet generation mismatch due to possible roll-back"
     "expr": |
-      kube_statefulset_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_statefulset_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_statefulset_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_statefulset_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -113,18 +113,18 @@
     "expr": |
       (
         max without (revision) (
-          kube_statefulset_status_current_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_current_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
             unless
-          kube_statefulset_status_update_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_update_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
           *
         (
-          kube_statefulset_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
             !=
-          kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
       )  and (
-        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+        changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -140,24 +140,24 @@
     "expr": |
       (
         (
-          kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
           0
         ) or (
-          kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         )
       ) and (
-        changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+        changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -171,7 +171,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
       "summary": "Pod container waiting longer than 1 hour"
     "expr": |
-      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
+      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -182,9 +182,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
       "summary": "DaemonSet pods are not scheduled."
     "expr": |
-      kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         -
-      kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "10m"
     "labels":
       "severity": "warning"
@@ -195,7 +195,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
       "summary": "DaemonSet pods are misscheduled."
     "expr": |
-      kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -206,9 +206,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
       "summary": "Job did not complete in time"
     "expr": |
-      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         and
-      kube_job_status_active{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
+      kube_job_status_active{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
     "labels":
       "severity": "warning"
       "source": "mixin/kubernetes"
@@ -218,7 +218,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
       "summary": "Job failed to complete."
     "expr": |
-      kube_job_failed{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
+      kube_job_failed{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -229,19 +229,19 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
       "summary": "HPA has not matched desired number of replicas."
     "expr": |
-      (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         !=
-      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         >
-      kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         <
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
         and
-      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
+      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -252,9 +252,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
       "summary": "HPA is running at max replicas"
     "expr": |
-      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
         ==
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "info"
@@ -293,7 +293,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
       "summary": "Cluster has overcommitted CPU resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
         /
       sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
         > 1.5
@@ -307,7 +307,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
       "summary": "Cluster has overcommitted memory resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+      sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
         /
       sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
         > 1.5
@@ -321,9 +321,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
       "summary": "Namespace quota is going to be full."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         > 0.9 < 1
     "for": "15m"
     "labels":
@@ -335,9 +335,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
       "summary": "Namespace quota is fully used."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         == 1
     "for": "15m"
     "labels":
@@ -349,9 +349,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
       "summary": "Namespace quota has exceeded the limits."
     "expr": |
-      kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
         > 1
     "for": "15m"
     "labels":
@@ -380,16 +380,16 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -401,18 +401,18 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -424,16 +424,16 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -445,18 +445,18 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -467,7 +467,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
       "summary": "PersistentVolume is having issues with provisioning."
     "expr": |
-      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
     "for": "5m"
     "labels":
       "severity": "critical"

--- a/resources/mixins/kubernetes/jsonnetfile.lock.json
+++ b/resources/mixins/kubernetes/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "f0b70307b8e5f12236b277883d998af129a8211f",
+      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
       "sum": "342u++/7rViR/zj2jeJOjshzglkZ1SY+hFNuyCBFMdc="
     },
     {
@@ -18,8 +18,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "1cb605505efe5a630f00993ff611a241fdcc264f",
-      "sum": "tDR6yT2GVfw0wTU12iZH+m01HrbIr6g/xN+/8nzNkU0="
+      "version": "48da1834254f19d592a33ccfee18159af96be6f3",
+      "sum": "wp/L/9smcsHIiy24DH5WWMv2fcSckN2Lw/m7qDszaWU="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": ""
         }
       },
-      "version": "eed459199703c969afc318ea55b9361ae48180a7",
-      "sum": "iKDOR7+jXw3Rctog6Z1ofweIK5BLjuGeguIZjXLP8ls="
+      "version": "003ba5eadfbd69817d1215952133d3ecf99fbd92",
+      "sum": "2ZvQR3ld4JuX0PC3IYMri/jbeW7ko3ni2Ukrz2QnG3M="
     }
   ],
   "legacyImports": false

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -9,7 +9,7 @@ kubernetes {
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
-    namespaceSelector: 'namespace=~"rhacs-.*|acscs-.*"',
+    namespaceSelector: 'namespace=~"rhacs|rhacs-.*|acscs-.*"',
   },
 } + {
   // Customize alert labels.

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -9,7 +9,7 @@ kubernetes {
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
-    kubeStateMetricsSelector: 'namespace!~"openshift-.*',
+    namespaceSelector: 'namespace=~"rhacs-.*|acscs-.*"',
   },
 } + {
   // Customize alert labels.

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -9,6 +9,7 @@ kubernetes {
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
+    kubeStateMetricsSelector: 'namespace!~"openshift-.*',
   },
 } + {
   // Customize alert labels.

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -9,7 +9,7 @@ kubernetes {
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
-    namespaceSelector: 'namespace=~"rhacs|rhacs-.*|acscs-.*"',
+    namespaceSelector: 'namespace!~"openshift-kube.*|kube.*"'
   },
 } + {
   // Customize alert labels.

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -14,7 +14,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
             "summary": "Pod is crash looping."
           "expr": |
-            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", job="kube-state-metrics"}[5m]) >= 1
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -27,7 +27,7 @@ spec:
           "expr": |
             sum by (namespace, pod, cluster) (
               max by(namespace, pod, cluster) (
-                kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+                kube_pod_status_phase{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
               ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
                 1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
               )
@@ -42,9 +42,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
             "summary": "Deployment generation mismatch due to possible roll-back"
           "expr": |
-            kube_deployment_status_observed_generation{job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_deployment_metadata_generation{job="kube-state-metrics"}
+            kube_deployment_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -56,14 +56,26 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_deployment_spec_replicas{job="kube-state-metrics"}
+              kube_deployment_spec_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                 >
-              kube_deployment_status_replicas_available{job="kube-state-metrics"}
+              kube_deployment_status_replicas_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_deployment_status_replicas_updated{job="kube-state-metrics"}[10m])
+              changes(kube_deployment_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
+          "for": "15m"
+          "labels":
+            "severity": "warning"
+            "source": "mixin/kubernetes"
+        - "alert": "KubeDeploymentRolloutStuck"
+          "annotations":
+            "description": "Rollout of deployment {{ $labels.namespace }}/{{ $labels.deployment }} is not progressing for longer than 15 minutes."
+            "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
+            "summary": "Deployment rollout is not progressing."
+          "expr": |
+            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            != 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -75,11 +87,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+              kube_statefulset_status_replicas_ready{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                 !=
-              kube_statefulset_status_replicas{job="kube-state-metrics"}
+              kube_statefulset_status_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[10m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -93,9 +105,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
             "summary": "StatefulSet generation mismatch due to possible roll-back"
           "expr": |
-            kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_statefulset_metadata_generation{job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -108,18 +120,18 @@ spec:
           "expr": |
             (
               max without (revision) (
-                kube_statefulset_status_current_revision{job="kube-state-metrics"}
+                kube_statefulset_status_current_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                   unless
-                kube_statefulset_status_update_revision{job="kube-state-metrics"}
+                kube_statefulset_status_update_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
                 *
               (
-                kube_statefulset_replicas{job="kube-state-metrics"}
+                kube_statefulset_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                   !=
-                kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+                kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
             )  and (
-              changes(kube_statefulset_status_replicas_updated{job="kube-state-metrics"}[5m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -135,24 +147,24 @@ spec:
           "expr": |
             (
               (
-                kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"}
+                kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+                kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
                 0
               ) or (
-                kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}
+                kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_available{job="kube-state-metrics"}
+                kube_daemonset_status_number_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
             ) and (
-              changes(kube_daemonset_status_updated_number_scheduled{job="kube-state-metrics"}[5m])
+              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -166,7 +178,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
             "summary": "Pod container waiting longer than 1 hour"
           "expr": |
-            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -177,9 +189,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
             "summary": "DaemonSet pods are not scheduled."
           "expr": |
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               -
-            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "10m"
           "labels":
             "severity": "warning"
@@ -190,7 +202,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
             "summary": "DaemonSet pods are misscheduled."
           "expr": |
-            kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -201,9 +213,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
             "summary": "Job did not complete in time"
           "expr": |
-            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{job="kube-state-metrics"}
+            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               and
-            kube_job_status_active{job="kube-state-metrics"} > 0) > 43200
+            kube_job_status_active{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
           "labels":
             "severity": "warning"
             "source": "mixin/kubernetes"
@@ -213,7 +225,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
             "summary": "Job failed to complete."
           "expr": |
-            kube_job_failed{job="kube-state-metrics"}  > 0
+            kube_job_failed{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -224,19 +236,19 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
             "summary": "HPA has not matched desired number of replicas."
           "expr": |
-            (kube_horizontalpodautoscaler_status_desired_replicas{job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               >
-            kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               <
-            kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            changes(kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}[15m]) == 0
+            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -247,9 +259,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
             "summary": "HPA is running at max replicas"
           "expr": |
-            kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ==
-            kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "info"
@@ -288,7 +300,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
             "summary": "Cluster has overcommitted CPU resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
               /
             sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
               > 1.5
@@ -302,7 +314,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
             "summary": "Cluster has overcommitted memory resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
               /
             sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
               > 1.5
@@ -316,9 +328,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
             "summary": "Namespace quota is going to be full."
           "expr": |
-            kube_resourcequota{job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               > 0.9 < 1
           "for": "15m"
           "labels":
@@ -330,9 +342,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
             "summary": "Namespace quota is fully used."
           "expr": |
-            kube_resourcequota{job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               == 1
           "for": "15m"
           "labels":
@@ -344,9 +356,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
             "summary": "Namespace quota has exceeded the limits."
           "expr": |
-            kube_resourcequota{job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               > 1
           "for": "15m"
           "labels":
@@ -375,16 +387,16 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_used_bytes{job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -396,18 +408,18 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_used_bytes{job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -419,16 +431,16 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{job="kubelet"}
+              kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_inodes_used{job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -440,18 +452,18 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{job="kubelet"}
+              kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_inodes_used{job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -462,7 +474,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
             "summary": "PersistentVolume is having issues with provisioning."
           "expr": |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "5m"
           "labels":
             "severity": "critical"
@@ -564,7 +576,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeaggregatedapierrors"
             "summary": "Kubernetes aggregated API has reported errors."
           "expr": |
-            sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total[10m])) > 4
+            sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="api"}[10m])) > 4
           "labels":
             "severity": "warning"
             "source": "mixin/kubernetes"
@@ -574,7 +586,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeaggregatedapidown"
             "summary": "Kubernetes aggregated API is down."
           "expr": |
-            (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice[10m]))) * 100 < 85
+            (1 - max by(name, namespace, cluster)(avg_over_time(aggregator_unavailable_apiservice{job="api"}[10m]))) * 100 < 85
           "for": "5m"
           "labels":
             "severity": "warning"

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -14,7 +14,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
             "summary": "Pod is crash looping."
           "expr": |
-            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -27,7 +27,7 @@ spec:
           "expr": |
             sum by (namespace, pod, cluster) (
               max by(namespace, pod, cluster) (
-                kube_pod_status_phase{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+                kube_pod_status_phase{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
               ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
                 1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
               )
@@ -42,9 +42,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
             "summary": "Deployment generation mismatch due to possible roll-back"
           "expr": |
-            kube_deployment_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_deployment_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -56,11 +56,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_deployment_spec_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_deployment_spec_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                 >
-              kube_deployment_status_replicas_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_deployment_status_replicas_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_deployment_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+              changes(kube_deployment_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -74,7 +74,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
             "summary": "Deployment rollout is not progressing."
           "expr": |
-            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
             != 0
           "for": "15m"
           "labels":
@@ -87,11 +87,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_statefulset_status_replicas_ready{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas_ready{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                 !=
-              kube_statefulset_status_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -105,9 +105,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
             "summary": "StatefulSet generation mismatch due to possible roll-back"
           "expr": |
-            kube_statefulset_status_observed_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_statefulset_metadata_generation{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -120,18 +120,18 @@ spec:
           "expr": |
             (
               max without (revision) (
-                kube_statefulset_status_current_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_current_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                   unless
-                kube_statefulset_status_update_revision{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_update_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
                 *
               (
-                kube_statefulset_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                   !=
-                kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
             )  and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -147,24 +147,24 @@ spec:
           "expr": |
             (
               (
-                kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
                 0
               ) or (
-                kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_available{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               )
             ) and (
-              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -178,7 +178,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
             "summary": "Pod container waiting longer than 1 hour"
           "expr": |
-            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -189,9 +189,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
             "summary": "DaemonSet pods are not scheduled."
           "expr": |
-            kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               -
-            kube_daemonset_status_current_number_scheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "10m"
           "labels":
             "severity": "warning"
@@ -202,7 +202,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
             "summary": "DaemonSet pods are misscheduled."
           "expr": |
-            kube_daemonset_status_number_misscheduled{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -213,9 +213,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
             "summary": "Job did not complete in time"
           "expr": |
-            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               and
-            kube_job_status_active{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
+            kube_job_status_active{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
           "labels":
             "severity": "warning"
             "source": "mixin/kubernetes"
@@ -225,7 +225,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
             "summary": "Job failed to complete."
           "expr": |
-            kube_job_failed{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
+            kube_job_failed{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -236,19 +236,19 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
             "summary": "HPA has not matched desired number of replicas."
           "expr": |
-            (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               !=
-            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               >
-            kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               <
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
               and
-            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
+            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -259,9 +259,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
             "summary": "HPA is running at max replicas"
           "expr": |
-            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
               ==
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "info"
@@ -300,7 +300,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
             "summary": "Cluster has overcommitted CPU resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
               /
             sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
               > 1.5
@@ -314,7 +314,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
             "summary": "Cluster has overcommitted memory resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
               /
             sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
               > 1.5
@@ -328,9 +328,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
             "summary": "Namespace quota is going to be full."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               > 0.9 < 1
           "for": "15m"
           "labels":
@@ -342,9 +342,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
             "summary": "Namespace quota is fully used."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               == 1
           "for": "15m"
           "labels":
@@ -356,9 +356,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
             "summary": "Namespace quota has exceeded the limits."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
               > 1
           "for": "15m"
           "labels":
@@ -387,16 +387,16 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -408,18 +408,18 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_used_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -431,16 +431,16 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -452,18 +452,18 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_inodes_used{namespace=~"rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -474,7 +474,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
             "summary": "PersistentVolume is having issues with provisioning."
           "expr": |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
           "for": "5m"
           "labels":
             "severity": "critical"

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -14,7 +14,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
             "summary": "Pod is crash looping."
           "expr": |
-            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m]) >= 1
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m]) >= 1
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -27,7 +27,7 @@ spec:
           "expr": |
             sum by (namespace, pod, cluster) (
               max by(namespace, pod, cluster) (
-                kube_pod_status_phase{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+                kube_pod_status_phase{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
               ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
                 1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
               )
@@ -42,9 +42,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
             "summary": "Deployment generation mismatch due to possible roll-back"
           "expr": |
-            kube_deployment_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               !=
-            kube_deployment_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -56,11 +56,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_deployment_spec_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_deployment_spec_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                 >
-              kube_deployment_status_replicas_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_deployment_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+              changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -74,7 +74,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
             "summary": "Deployment rollout is not progressing."
           "expr": |
-            kube_deployment_status_condition{condition="Progressing", status="false",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
             != 0
           "for": "15m"
           "labels":
@@ -87,11 +87,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_statefulset_status_replicas_ready{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                 !=
-              kube_statefulset_status_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[10m])
+              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -105,9 +105,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
             "summary": "StatefulSet generation mismatch due to possible roll-back"
           "expr": |
-            kube_statefulset_status_observed_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               !=
-            kube_statefulset_metadata_generation{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -120,18 +120,18 @@ spec:
           "expr": |
             (
               max without (revision) (
-                kube_statefulset_status_current_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                   unless
-                kube_statefulset_status_update_revision{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               )
                 *
               (
-                kube_statefulset_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                   !=
-                kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               )
             )  and (
-              changes(kube_statefulset_status_replicas_updated{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -147,24 +147,24 @@ spec:
           "expr": |
             (
               (
-                kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                  !=
                 0
               ) or (
-                kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_available{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               )
             ) and (
-              changes(kube_daemonset_status_updated_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[5m])
+              changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -178,7 +178,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
             "summary": "Pod container waiting longer than 1 hour"
           "expr": |
-            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}) > 0
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -189,9 +189,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
             "summary": "DaemonSet pods are not scheduled."
           "expr": |
-            kube_daemonset_status_desired_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               -
-            kube_daemonset_status_current_number_scheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
           "for": "10m"
           "labels":
             "severity": "warning"
@@ -202,7 +202,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
             "summary": "DaemonSet pods are misscheduled."
           "expr": |
-            kube_daemonset_status_number_misscheduled{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -213,9 +213,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
             "summary": "Job did not complete in time"
           "expr": |
-            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               and
-            kube_job_status_active{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0) > 43200
+            kube_job_status_active{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0) > 43200
           "labels":
             "severity": "warning"
             "source": "mixin/kubernetes"
@@ -225,7 +225,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
             "summary": "Job failed to complete."
           "expr": |
-            kube_job_failed{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}  > 0
+            kube_job_failed{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}  > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -236,19 +236,19 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
             "summary": "HPA has not matched desired number of replicas."
           "expr": |
-            (kube_horizontalpodautoscaler_status_desired_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               !=
-            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               >
-            kube_horizontalpodautoscaler_spec_min_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               <
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
               and
-            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}[15m]) == 0
+            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[15m]) == 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -259,9 +259,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
             "summary": "HPA is running at max replicas"
           "expr": |
-            kube_horizontalpodautoscaler_status_current_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
               ==
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "info"
@@ -300,7 +300,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
             "summary": "Cluster has overcommitted CPU resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
               /
             sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
               > 1.5
@@ -314,7 +314,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
             "summary": "Cluster has overcommitted memory resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
               /
             sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
               > 1.5
@@ -328,9 +328,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
             "summary": "Namespace quota is going to be full."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
               > 0.9 < 1
           "for": "15m"
           "labels":
@@ -342,9 +342,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
             "summary": "Namespace quota is fully used."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
               == 1
           "for": "15m"
           "labels":
@@ -356,9 +356,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
             "summary": "Namespace quota has exceeded the limits."
           "expr": |
-            kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
               > 1
           "for": "15m"
           "labels":
@@ -387,16 +387,16 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -408,18 +408,18 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_used_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_available_bytes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -431,16 +431,16 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -452,18 +452,18 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_inodes_used{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_inodes_free{namespace=~"rhacs|rhacs-.*|acscs-.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace=~"rhacs|rhacs-.*|acscs-.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace=~"rhacs|rhacs-.*|acscs-.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -474,7 +474,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
             "summary": "PersistentVolume is having issues with provisioning."
           "expr": |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"rhacs|rhacs-.*|acscs-.*",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
           "for": "5m"
           "labels":
             "severity": "critical"


### PR DESCRIPTION
Set `namespaceSelector: 'namespace=~"rhacs-.*|acscs-.*"'` in jsonnet `_config`, to effectively have alerts only on ACS workloads.

See [the related thread](https://redhat-internal.slack.com/archives/CCX9DB894/p1687381918802879?thread_ts=1687297268.055499&cid=CCX9DB894) for the context on why SRE supports this.
