### PR TITLE
Increase paused central alert warning duration

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -179,11 +179,11 @@ spec:
         - alert: RHACSFleetshardSyncCentralReconcilePaused
           expr: |
             acs_fleetshard_pause_reconcile_instances == 1
-          for: 2d
+          for: 30d
           labels:
             severity: warning
           annotations:
-            summary: "ACS instance {{ $labels.instance }} has paused reconciliation for more than 2 days."
+            summary: "ACS instance {{ $labels.instance }} has paused reconciliation for more than 30 days."
             description: "ACS instance {{ $labels.instance }} has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
     - name: rhacs-aws-quota
       rules:

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -178,13 +178,13 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
         - alert: RHACSFleetshardSyncCentralReconcilePaused
           expr: |
-            acs_fleetshard_pause_reconcile_instances == 1
+            sum by (exported_instance) (acs_fleetshard_pause_reconcile_instances) >= 1
           for: 30d
           labels:
             severity: warning
           annotations:
-            summary: "ACS instance {{ $labels.instance }} has paused reconciliation for more than 30 days."
-            description: "ACS instance {{ $labels.instance }} has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
+            summary: "ACS instance {{ $labels.exported_instance }} has paused reconciliation for more than 30 days."
+            description: "ACS instance {{ $labels.exported_instance }} has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
     - name: rhacs-aws-quota
       rules:
         - alert: RHACSCentralDBClustersUtilizationHigh

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
@@ -12,10 +12,10 @@ tests:
       - eval_time: 1h
         alertname: RHACSFleetshardSyncCentralReconcilePaused
         exp_alerts: []
-      - eval_time: 30h
+      - eval_time: 20d
         alertname: RHACSFleetshardSyncCentralReconcilePaused
         exp_alerts: []
-      - eval_time: 49h
+      - eval_time: 31d
         alertname: RHACSFleetshardSyncCentralReconcilePaused
         exp_alerts:
           - exp_labels:
@@ -23,7 +23,7 @@ tests:
               instance: rhacs-chs64i3dabr0026a6fag
               severity: warning
             exp_annotations:
-              summary: "ACS instance rhacs-chs64i3dabr0026a6fag has paused reconciliation for more than 2 days."
+              summary: "ACS instance rhacs-chs64i3dabr0026a6fag has paused reconciliation for more than 30 days."
               description: "ACS instance rhacs-chs64i3dabr0026a6fag has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
       - eval_time: 52h
         alertname: RHACSFleetshardSyncCentralReconcilePaused

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
@@ -1,13 +1,13 @@
 rule_files:
   - /tmp/prometheus-rules-test.yaml
 
-evaluation_interval: 5d
+evaluation_interval: 1h
 
 tests:
   - interval: 1h
     input_series:
-      - series: acs_fleetshard_pause_reconcile_instances{instance="rhacs-chs64i3dabr0026a6fag"}
-        values: "0+0x0 1+0x50 0+0x2"
+      - series: acs_fleetshard_pause_reconcile_instances{exported_instance="chs64i3dabr0026a6fag"}
+        values: "0+0x0 1+0x750 0+0x24"
     alert_rule_test:
       - eval_time: 1h
         alertname: RHACSFleetshardSyncCentralReconcilePaused
@@ -20,11 +20,11 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: RHACSFleetshardSyncCentralReconcilePaused
-              instance: rhacs-chs64i3dabr0026a6fag
+              exported_instance: chs64i3dabr0026a6fag
               severity: warning
             exp_annotations:
-              summary: "ACS instance rhacs-chs64i3dabr0026a6fag has paused reconciliation for more than 30 days."
-              description: "ACS instance rhacs-chs64i3dabr0026a6fag has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
-      - eval_time: 36d
+              summary: "ACS instance chs64i3dabr0026a6fag has paused reconciliation for more than 30 days."
+              description: "ACS instance chs64i3dabr0026a6fag has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
+      - eval_time: 32d
         alertname: RHACSFleetshardSyncCentralReconcilePaused
         exp_alerts: []

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralReconcilePaused.yaml
@@ -1,7 +1,7 @@
 rule_files:
   - /tmp/prometheus-rules-test.yaml
 
-evaluation_interval: 1h
+evaluation_interval: 5d
 
 tests:
   - interval: 1h
@@ -25,6 +25,6 @@ tests:
             exp_annotations:
               summary: "ACS instance rhacs-chs64i3dabr0026a6fag has paused reconciliation for more than 30 days."
               description: "ACS instance rhacs-chs64i3dabr0026a6fag has the 'pause-reconcile' annotation and therefore is not being managed by the ACS operator. Please check that this is intended."
-      - eval_time: 52h
+      - eval_time: 36d
         alertname: RHACSFleetshardSyncCentralReconcilePaused
         exp_alerts: []


### PR DESCRIPTION
Increase the duration of the paused instance alert to 30 days.
We expect a release every 9 weeks, therefore alerting after two days is too early to alert a warning when no fix was released for ACS.