### PR TITLE
use max values over time in probe alert

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -236,13 +236,16 @@ spec:
     - name: rhacs-probe
       rules:
         - alert: RHACSProbeRunFailed
-          expr: acs_probe_last_failure_timestamp > 0 and acs_probe_last_failure_timestamp >= acs_probe_last_success_timestamp
+          expr: |
+            max by (region, rhacs_cluster_name, rhacs_environment) (max_over_time(acs_probe_last_failure_timestamp[1w]))
+              >
+            max by (region, rhacs_cluster_name, rhacs_environment) (max_over_time(acs_probe_last_success_timestamp[1w]))
           for: 30m
           labels:
             severity: critical
           annotations:
             summary: "The latest probe run failed at `{{ $value | humanizeTimestamp }}`."
-            description: "The latest run of probe `{{ $labels.pod }}` failed at `{{ $value | humanizeTimestamp }}`."
+            description: "The latest probe run in region `{{ $labels.region }}` on cluster `{{ $labels.rhacs_cluster_name }}` failed at `{{ $value | humanizeTimestamp }}`."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-008-probe-run-failed.md"
         - alert: RHACSProbeScrapeFailed
           expr: |

--- a/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
+++ b/resources/prometheus/unit_tests/RHACSProbeRunFailed.yaml
@@ -6,10 +6,10 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: acs_probe_last_failure_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0+0x10 0+0x15 7+0x60"
-      - series: acs_probe_last_success_timestamp{namespace="rhacs-probe", pod="probe-1234"}
-        values: "0+0x10 1+1x15 6+0x60"
+      - series: acs_probe_last_failure_timestamp{namespace="rhacs-probe", region="eu-west-1", rhacs_cluster_name="acs-eu-1"}
+        values: "0+0x15 17+1x60"
+      - series: acs_probe_last_success_timestamp{namespace="rhacs-probe", region="eu-west-1", rhacs_cluster_name="acs-eu-1"}
+        values: "1+1x15 17+0x60"
     alert_rule_test:
       - eval_time: 0m
         alertname: RHACSProbeRunFailed
@@ -23,9 +23,9 @@ tests:
           - exp_labels:
               alertname: RHACSProbeRunFailed
               severity: critical
-              namespace: rhacs-probe
-              pod: probe-1234
+              region: eu-west-1
+              rhacs_cluster_name: "acs-eu-1"
             exp_annotations:
-              summary: "The latest probe run failed at `1970-01-01 00:00:07 +0000 UTC`."
-              description: "The latest run of probe `probe-1234` failed at `1970-01-01 00:00:07 +0000 UTC`."
+              summary: "The latest probe run failed at `1970-01-01 00:01:01 +0000 UTC`."
+              description: "The latest probe run in region `eu-west-1` on cluster `acs-eu-1` failed at `1970-01-01 00:01:01 +0000 UTC`."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-008-probe-run-failed.md"


### PR DESCRIPTION
This addresses an issue with the current probe alerting condition. If the probe fails from the very beginning when the probe pod is live, `acs_probe_last_success_timestamp` is never defined and the condition does not evaluate to true. To fix this, we look back a week and find the last recorded timestamps of any probe pod.