### PR TITLE
Ignore kube-mixin alerts for openshift-marketplace

### DIFF
--- a/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
@@ -549,8 +549,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -780,8 +779,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
@@ -789,8 +787,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
@@ -798,8 +795,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -807,8 +803,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -816,8 +811,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -825,8 +819,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -834,8 +827,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "G",
-                  "step": 10
+                  "refId": "G"
                 }
               ],
               "thresholds": [],
@@ -926,8 +918,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1157,8 +1148,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
@@ -1166,8 +1156,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
@@ -1175,8 +1164,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1184,8 +1172,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1193,8 +1180,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1202,8 +1188,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 },
                 {
                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1211,8 +1196,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "G",
-                  "step": 10
+                  "refId": "G"
                 }
               ],
               "thresholds": [],
@@ -1428,8 +1412,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1437,8 +1420,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1446,8 +1428,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1455,8 +1436,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1464,8 +1444,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1473,8 +1452,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -1565,8 +1543,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1644,8 +1621,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1735,8 +1711,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1814,8 +1789,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1905,8 +1879,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1984,8 +1957,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2075,8 +2047,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2154,8 +2125,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2246,8 +2216,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2325,8 +2294,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{namespace}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2545,8 +2513,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2554,8 +2521,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2563,8 +2529,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2572,8 +2537,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2581,8 +2545,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2590,8 +2553,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],

--- a/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
@@ -414,24 +414,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -631,8 +628,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -640,8 +636,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -649,8 +644,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -658,8 +652,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -667,8 +660,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 }
               ],
               "thresholds": [],
@@ -782,24 +774,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1044,8 +1033,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1053,8 +1041,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1062,8 +1049,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1071,8 +1057,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1080,8 +1065,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1089,8 +1073,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 },
                 {
                   "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1098,8 +1081,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "G",
-                  "step": 10
+                  "refId": "G"
                 },
                 {
                   "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1107,8 +1089,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "H",
-                  "step": 10
+                  "refId": "H"
                 }
               ],
               "thresholds": [],
@@ -1324,8 +1305,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1333,8 +1313,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1342,8 +1321,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1351,8 +1329,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1360,8 +1337,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1369,8 +1345,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -1461,8 +1436,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1540,8 +1514,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1631,8 +1604,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1710,8 +1682,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1801,8 +1772,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1880,8 +1850,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1972,8 +1941,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2051,8 +2019,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -2271,8 +2238,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2280,8 +2246,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2289,8 +2254,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2298,8 +2262,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2307,8 +2270,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2316,8 +2278,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],

--- a/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
@@ -75,16 +75,14 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "max capacity",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -284,8 +282,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -293,8 +290,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -302,8 +298,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -311,8 +306,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -320,8 +314,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 }
               ],
               "thresholds": [],
@@ -424,16 +417,14 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "max capacity",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -678,8 +669,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -687,8 +677,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -696,8 +685,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -705,8 +693,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -714,8 +701,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -723,8 +709,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -732,8 +717,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "G",
-                  "step": 10
+                  "refId": "G"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -741,8 +725,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "H",
-                  "step": 10
+                  "refId": "H"
                 }
               ],
               "thresholds": [],

--- a/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
@@ -82,24 +82,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{container}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -189,8 +186,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{container}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [
@@ -399,8 +395,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -408,8 +403,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -417,8 +411,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -426,8 +419,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -435,8 +427,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 }
               ],
               "thresholds": [],
@@ -548,24 +539,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{container}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -810,8 +798,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -819,8 +806,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -828,8 +814,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -837,8 +822,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -846,8 +830,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -855,8 +838,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 },
                 {
                   "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -864,8 +846,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "G",
-                  "step": 10
+                  "refId": "G"
                 },
                 {
                   "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -873,8 +854,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "H",
-                  "step": 10
+                  "refId": "H"
                 }
               ],
               "thresholds": [],
@@ -965,8 +945,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1044,8 +1023,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1135,8 +1113,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1214,8 +1191,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1305,8 +1281,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1384,8 +1359,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1476,16 +1450,14 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Reads",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Writes",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1563,16 +1535,14 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Reads",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "Writes",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1663,8 +1633,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{container}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1742,8 +1711,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{container}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1962,8 +1930,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1971,8 +1938,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1980,8 +1946,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1989,8 +1954,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1998,8 +1962,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -2007,8 +1970,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
@@ -63,8 +63,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -264,8 +263,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -273,8 +271,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -282,8 +279,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -291,8 +287,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -300,8 +295,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 }
               ],
               "thresholds": [],
@@ -392,8 +386,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -593,8 +586,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -602,8 +594,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -611,8 +602,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -620,8 +610,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -629,8 +618,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 }
               ],
               "thresholds": [],
@@ -846,8 +834,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -855,8 +842,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -864,8 +850,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -873,8 +858,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -882,8 +866,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -891,8 +874,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -983,8 +965,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1062,8 +1043,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1153,8 +1133,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1232,8 +1211,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1323,8 +1301,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1402,8 +1379,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1493,8 +1469,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1572,8 +1547,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{pod}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
@@ -86,24 +86,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}} - {{workload_type}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -333,8 +330,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -342,8 +338,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -351,8 +346,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -360,8 +354,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -369,8 +362,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -378,8 +370,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -493,24 +484,21 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}} - {{workload_type}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - requests",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 },
                 {
                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "quota - limits",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -740,8 +728,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -749,8 +736,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -758,8 +744,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -767,8 +752,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -776,8 +760,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -785,8 +768,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -1017,8 +999,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "A",
-                  "step": 10
+                  "refId": "A"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1026,8 +1007,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "B",
-                  "step": 10
+                  "refId": "B"
                 },
                 {
                   "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1035,8 +1015,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "C",
-                  "step": 10
+                  "refId": "C"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1044,8 +1023,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "D",
-                  "step": 10
+                  "refId": "D"
                 },
                 {
                   "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1053,8 +1031,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "E",
-                  "step": 10
+                  "refId": "E"
                 },
                 {
                   "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1062,8 +1039,7 @@ spec:
                   "instant": true,
                   "intervalFactor": 2,
                   "legendFormat": "",
-                  "refId": "F",
-                  "step": 10
+                  "refId": "F"
                 }
               ],
               "thresholds": [],
@@ -1154,8 +1130,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1233,8 +1208,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1324,8 +1298,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1403,8 +1376,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1494,8 +1466,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1573,8 +1544,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1664,8 +1634,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],
@@ -1743,8 +1712,7 @@ spec:
                   "format": "time_series",
                   "intervalFactor": 2,
                   "legendFormat": "{{workload}}",
-                  "legendLink": null,
-                  "step": 10
+                  "legendLink": null
                 }
               ],
               "thresholds": [],

--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -7,7 +7,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
       "summary": "Pod is crash looping."
     "expr": |
-      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m]) >= 1
+      max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m]) >= 1
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -20,7 +20,7 @@
     "expr": |
       sum by (namespace, pod, cluster) (
         max by(namespace, pod, cluster) (
-          kube_pod_status_phase{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+          kube_pod_status_phase{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
         ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
           1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
         )
@@ -35,9 +35,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
       "summary": "Deployment generation mismatch due to possible roll-back"
     "expr": |
-      kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         !=
-      kube_deployment_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_deployment_metadata_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -49,11 +49,11 @@
       "summary": "Deployment has not matched the expected number of replicas."
     "expr": |
       (
-        kube_deployment_spec_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+        kube_deployment_spec_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
           >
-        kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+        kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
+        changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -67,7 +67,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
       "summary": "Deployment rollout is not progressing."
     "expr": |
-      kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
       != 0
     "for": "15m"
     "labels":
@@ -77,14 +77,14 @@
     "annotations":
       "description": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
-      "summary": "Deployment has not matched the expected number of replicas."
+      "summary": "StatefulSet has not matched the expected number of replicas."
     "expr": |
       (
-        kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
           !=
-        kube_statefulset_status_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+        kube_statefulset_status_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
       ) and (
-        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
+        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[10m])
           ==
         0
       )
@@ -98,9 +98,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
       "summary": "StatefulSet generation mismatch due to possible roll-back"
     "expr": |
-      kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         !=
-      kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -113,18 +113,18 @@
     "expr": |
       (
         max without (revision) (
-          kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
             unless
-          kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         )
           *
         (
-          kube_statefulset_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_statefulset_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
             !=
-          kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         )
       )  and (
-        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
+        changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -140,24 +140,24 @@
     "expr": |
       (
         (
-          kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
            !=
           0
         ) or (
-          kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         ) or (
-          kube_daemonset_status_number_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_number_available{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
            !=
-          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+          kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         )
       ) and (
-        changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
+        changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m])
           ==
         0
       )
@@ -171,7 +171,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
       "summary": "Pod container waiting longer than 1 hour"
     "expr": |
-      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}) > 0
+      sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}) > 0
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -182,9 +182,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
       "summary": "DaemonSet pods are not scheduled."
     "expr": |
-      kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         -
-      kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
     "for": "10m"
     "labels":
       "severity": "warning"
@@ -195,7 +195,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
       "summary": "DaemonSet pods are misscheduled."
     "expr": |
-      kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+      kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -206,9 +206,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
       "summary": "Job did not complete in time"
     "expr": |
-      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         and
-      kube_job_status_active{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0) > 43200
+      kube_job_status_active{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0) > 43200
     "labels":
       "severity": "warning"
       "source": "mixin/kubernetes"
@@ -218,7 +218,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
       "summary": "Job failed to complete."
     "expr": |
-      kube_job_failed{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}  > 0
+      kube_job_failed{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}  > 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -229,19 +229,19 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
       "summary": "HPA has not matched desired number of replicas."
     "expr": |
-      (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         !=
-      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         >
-      kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
         and
-      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         <
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
         and
-      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[15m]) == 0
+      changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[15m]) == 0
     "for": "15m"
     "labels":
       "severity": "warning"
@@ -252,9 +252,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
       "summary": "HPA is running at max replicas"
     "expr": |
-      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
         ==
-      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+      kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
     "for": "15m"
     "labels":
       "severity": "info"
@@ -293,7 +293,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
       "summary": "Cluster has overcommitted CPU resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
         /
       sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
         > 1.5
@@ -307,7 +307,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
       "summary": "Cluster has overcommitted memory resource requests."
     "expr": |
-      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+      sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
         /
       sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
         > 1.5
@@ -321,9 +321,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
       "summary": "Namespace quota is going to be full."
     "expr": |
-      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
         > 0.9 < 1
     "for": "15m"
     "labels":
@@ -335,9 +335,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
       "summary": "Namespace quota is fully used."
     "expr": |
-      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
         == 1
     "for": "15m"
     "labels":
@@ -349,9 +349,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
       "summary": "Namespace quota has exceeded the limits."
     "expr": |
-      kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+      kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
         / ignoring(instance, job, type)
-      (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+      (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
         > 1
     "for": "15m"
     "labels":
@@ -380,16 +380,16 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -401,18 +401,18 @@
       "summary": "PersistentVolume is filling up."
     "expr": |
       (
-        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+      kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -424,16 +424,16 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
       ) < 0.03
       and
-      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
       "severity": "critical"
@@ -445,18 +445,18 @@
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
       (
-        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
           /
-        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+        kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
       ) < 0.15
       and
-      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+      kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
       and
-      predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+      predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+      kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(namespace, persistentvolumeclaim)
-      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+      kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
       "severity": "warning"
@@ -467,7 +467,7 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
       "summary": "PersistentVolume is having issues with provisioning."
     "expr": |
-      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+      kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
     "for": "5m"
     "labels":
       "severity": "critical"

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-cluster.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-cluster.json
@@ -538,8 +538,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -769,8 +768,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
@@ -778,8 +776,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
@@ -787,8 +784,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -796,8 +792,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -805,8 +800,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -814,8 +808,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -823,8 +816,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "G",
-                     "step": 10
+                     "refId": "G"
                   }
                ],
                "thresholds": [ ],
@@ -915,8 +907,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1146,8 +1137,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
@@ -1155,8 +1145,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
@@ -1164,8 +1153,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1173,8 +1161,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1182,8 +1169,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1191,8 +1177,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   },
                   {
                      "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
@@ -1200,8 +1185,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "G",
-                     "step": 10
+                     "refId": "G"
                   }
                ],
                "thresholds": [ ],
@@ -1417,8 +1401,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1426,8 +1409,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1435,8 +1417,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1444,8 +1425,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1453,8 +1433,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
@@ -1462,8 +1441,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -1554,8 +1532,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1633,8 +1610,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1724,8 +1700,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1803,8 +1778,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1894,8 +1868,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1973,8 +1946,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2064,8 +2036,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2143,8 +2114,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2235,8 +2205,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2314,8 +2283,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{namespace}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2534,8 +2502,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2543,8 +2510,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2552,8 +2518,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2561,8 +2526,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2570,8 +2534,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
@@ -2579,8 +2542,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-namespace.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-namespace.json
@@ -403,24 +403,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -620,8 +617,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -629,8 +625,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -638,8 +633,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -647,8 +641,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -656,8 +649,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
@@ -771,24 +763,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1033,8 +1022,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1042,8 +1030,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1051,8 +1038,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1060,8 +1046,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
@@ -1069,8 +1054,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1078,8 +1062,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   },
                   {
                      "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1087,8 +1070,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "G",
-                     "step": 10
+                     "refId": "G"
                   },
                   {
                      "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
@@ -1096,8 +1078,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "H",
-                     "step": 10
+                     "refId": "H"
                   }
                ],
                "thresholds": [ ],
@@ -1313,8 +1294,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1322,8 +1302,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1331,8 +1310,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1340,8 +1318,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1349,8 +1326,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
@@ -1358,8 +1334,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -1450,8 +1425,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1529,8 +1503,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1620,8 +1593,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1699,8 +1671,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1790,8 +1761,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1869,8 +1839,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1961,8 +1930,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2040,8 +2008,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -2260,8 +2227,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2269,8 +2235,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2278,8 +2243,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2287,8 +2251,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2296,8 +2259,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
@@ -2305,8 +2267,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-node.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-node.json
@@ -64,16 +64,14 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max capacity",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -273,8 +271,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -282,8 +279,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -291,8 +287,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -300,8 +295,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -309,8 +303,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
@@ -413,16 +406,14 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "max capacity",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -667,8 +658,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -676,8 +666,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -685,8 +674,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -694,8 +682,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
@@ -703,8 +690,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -712,8 +698,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -721,8 +706,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "G",
-                     "step": 10
+                     "refId": "G"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
@@ -730,8 +714,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "H",
-                     "step": 10
+                     "refId": "H"
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-pod.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-pod.json
@@ -71,24 +71,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -178,8 +175,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [
@@ -388,8 +384,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -397,8 +392,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -406,8 +400,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -415,8 +408,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -424,8 +416,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
@@ -537,24 +528,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -799,8 +787,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -808,8 +795,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -817,8 +803,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -826,8 +811,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
@@ -835,8 +819,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -844,8 +827,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   },
                   {
                      "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -853,8 +835,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "G",
-                     "step": 10
+                     "refId": "G"
                   },
                   {
                      "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
@@ -862,8 +843,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "H",
-                     "step": 10
+                     "refId": "H"
                   }
                ],
                "thresholds": [ ],
@@ -954,8 +934,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1033,8 +1012,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1124,8 +1102,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1203,8 +1180,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1294,8 +1270,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1373,8 +1348,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1465,16 +1439,14 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Reads",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Writes",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1552,16 +1524,14 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Reads",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "Writes",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1652,8 +1622,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1731,8 +1700,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{container}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1951,8 +1919,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1960,8 +1927,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1969,8 +1935,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1978,8 +1943,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1987,8 +1951,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
@@ -1996,8 +1959,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workload.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workload.json
@@ -52,8 +52,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -253,8 +252,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -262,8 +260,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -271,8 +268,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -280,8 +276,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -289,8 +284,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
@@ -381,8 +375,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -582,8 +575,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -591,8 +583,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -600,8 +591,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -609,8 +599,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
@@ -618,8 +607,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   }
                ],
                "thresholds": [ ],
@@ -835,8 +823,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -844,8 +831,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -853,8 +839,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -862,8 +847,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -871,8 +855,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
@@ -880,8 +863,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -972,8 +954,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1051,8 +1032,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1142,8 +1122,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1221,8 +1200,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1312,8 +1290,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1391,8 +1368,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1482,8 +1458,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1561,8 +1536,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{pod}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workloads-namespace.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workloads-namespace.json
@@ -75,24 +75,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}} - {{workload_type}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -322,8 +319,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -331,8 +327,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -340,8 +335,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -349,8 +343,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -358,8 +351,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -367,8 +359,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -482,24 +473,21 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}} - {{workload_type}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - requests",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   },
                   {
                      "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "quota - limits",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -729,8 +717,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -738,8 +725,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -747,8 +733,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -756,8 +741,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -765,8 +749,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
@@ -774,8 +757,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -1006,8 +988,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "A",
-                     "step": 10
+                     "refId": "A"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1015,8 +996,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "B",
-                     "step": 10
+                     "refId": "B"
                   },
                   {
                      "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1024,8 +1004,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "C",
-                     "step": 10
+                     "refId": "C"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1033,8 +1012,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "D",
-                     "step": 10
+                     "refId": "D"
                   },
                   {
                      "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1042,8 +1020,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "E",
-                     "step": 10
+                     "refId": "E"
                   },
                   {
                      "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
@@ -1051,8 +1028,7 @@
                      "instant": true,
                      "intervalFactor": 2,
                      "legendFormat": "",
-                     "refId": "F",
-                     "step": 10
+                     "refId": "F"
                   }
                ],
                "thresholds": [ ],
@@ -1143,8 +1119,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1222,8 +1197,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1313,8 +1287,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1392,8 +1365,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1483,8 +1455,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1562,8 +1533,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1653,8 +1623,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],
@@ -1732,8 +1701,7 @@
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{workload}}",
-                     "legendLink": null,
-                     "step": 10
+                     "legendLink": null
                   }
                ],
                "thresholds": [ ],

--- a/resources/mixins/kubernetes/jsonnetfile.lock.json
+++ b/resources/mixins/kubernetes/jsonnetfile.lock.json
@@ -18,8 +18,8 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "48da1834254f19d592a33ccfee18159af96be6f3",
-      "sum": "wp/L/9smcsHIiy24DH5WWMv2fcSckN2Lw/m7qDszaWU="
+      "version": "dac760854501e85dd2761160249f08aafff99a85",
+      "sum": "xEFMv4+ObwP5L1Wu0XK5agWci4AJzNApys6iKAQxLlQ="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": ""
         }
       },
-      "version": "003ba5eadfbd69817d1215952133d3ecf99fbd92",
-      "sum": "2ZvQR3ld4JuX0PC3IYMri/jbeW7ko3ni2Ukrz2QnG3M="
+      "version": "46fc905d5b2981642043088ac7902ea50db2903e",
+      "sum": "8FAie1MXww5Ip9F8hQWkU9Fio1Af+hO4weQuuexioIQ="
     }
   ],
   "legacyImports": false

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -9,7 +9,7 @@ kubernetes {
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
-    namespaceSelector: 'namespace!~"openshift-kube.*|kube.*"'
+    namespaceSelector: 'namespace!~"openshift-kube.*|openshift-marketplace|kube.*"'
   },
 } + {
   // Customize alert labels.

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -14,7 +14,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
             "summary": "Pod is crash looping."
           "expr": |
-            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m]) >= 1
+            max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m]) >= 1
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -27,7 +27,7 @@ spec:
           "expr": |
             sum by (namespace, pod, cluster) (
               max by(namespace, pod, cluster) (
-                kube_pod_status_phase{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
+                kube_pod_status_phase{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
               ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
                 1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
               )
@@ -42,9 +42,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
             "summary": "Deployment generation mismatch due to possible roll-back"
           "expr": |
-            kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               !=
-            kube_deployment_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_deployment_metadata_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -56,11 +56,11 @@ spec:
             "summary": "Deployment has not matched the expected number of replicas."
           "expr": |
             (
-              kube_deployment_spec_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+              kube_deployment_spec_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                 >
-              kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+              kube_deployment_status_replicas_available{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
+              changes(kube_deployment_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -74,7 +74,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentrolloutstuck"
             "summary": "Deployment rollout is not progressing."
           "expr": |
-            kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_deployment_status_condition{condition="Progressing", status="false",namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
             != 0
           "for": "15m"
           "labels":
@@ -84,14 +84,14 @@ spec:
           "annotations":
             "description": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
-            "summary": "Deployment has not matched the expected number of replicas."
+            "summary": "StatefulSet has not matched the expected number of replicas."
           "expr": |
             (
-              kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas_ready{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                 !=
-              kube_statefulset_status_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+              kube_statefulset_status_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
             ) and (
-              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[10m])
+              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[10m])
                 ==
               0
             )
@@ -105,9 +105,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
             "summary": "StatefulSet generation mismatch due to possible roll-back"
           "expr": |
-            kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               !=
-            kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -120,18 +120,18 @@ spec:
           "expr": |
             (
               max without (revision) (
-                kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_statefulset_status_current_revision{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                   unless
-                kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_statefulset_status_update_revision{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               )
                 *
               (
-                kube_statefulset_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_statefulset_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                   !=
-                kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               )
             )  and (
-              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
+              changes(kube_statefulset_status_replicas_updated{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -147,24 +147,24 @@ spec:
           "expr": |
             (
               (
-                kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                  !=
                 0
               ) or (
-                kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               ) or (
-                kube_daemonset_status_number_available{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_number_available{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
                  !=
-                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+                kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               )
             ) and (
-              changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[5m])
+              changes(kube_daemonset_status_updated_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[5m])
                 ==
               0
             )
@@ -178,7 +178,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting"
             "summary": "Pod container waiting longer than 1 hour"
           "expr": |
-            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container, cluster) (kube_pod_container_status_waiting_reason{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}) > 0
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -189,9 +189,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
             "summary": "DaemonSet pods are not scheduled."
           "expr": |
-            kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               -
-            kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
           "for": "10m"
           "labels":
             "severity": "warning"
@@ -202,7 +202,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
             "summary": "DaemonSet pods are misscheduled."
           "expr": |
-            kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -213,9 +213,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobnotcompleted"
             "summary": "Job did not complete in time"
           "expr": |
-            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            time() - max by(namespace, job_name, cluster) (kube_job_status_start_time{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               and
-            kube_job_status_active{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0) > 43200
+            kube_job_status_active{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0) > 43200
           "labels":
             "severity": "warning"
             "source": "mixin/kubernetes"
@@ -225,7 +225,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
             "summary": "Job failed to complete."
           "expr": |
-            kube_job_failed{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}  > 0
+            kube_job_failed{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}  > 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -236,19 +236,19 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch"
             "summary": "HPA has not matched desired number of replicas."
           "expr": |
-            (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_desired_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               !=
-            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               >
-            kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_min_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
               and
-            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            (kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               <
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"})
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"})
               and
-            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}[15m]) == 0
+            changes(kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}[15m]) == 0
           "for": "15m"
           "labels":
             "severity": "warning"
@@ -259,9 +259,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout"
             "summary": "HPA is running at max replicas"
           "expr": |
-            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_status_current_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
               ==
-            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"}
+            kube_horizontalpodautoscaler_spec_max_replicas{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"}
           "for": "15m"
           "labels":
             "severity": "info"
@@ -300,7 +300,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit"
             "summary": "Cluster has overcommitted CPU resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
+            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard", resource=~"(cpu|requests.cpu)"}))
               /
             sum(kube_node_status_allocatable{resource="cpu", job="kube-state-metrics"})
               > 1.5
@@ -314,7 +314,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit"
             "summary": "Cluster has overcommitted memory resource requests."
           "expr": |
-            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
+            sum(min without(resource) (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard", resource=~"(memory|requests.memory)"}))
               /
             sum(kube_node_status_allocatable{resource="memory", job="kube-state-metrics"})
               > 1.5
@@ -328,9 +328,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaalmostfull"
             "summary": "Namespace quota is going to be full."
           "expr": |
-            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
               > 0.9 < 1
           "for": "15m"
           "labels":
@@ -342,9 +342,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused"
             "summary": "Namespace quota is fully used."
           "expr": |
-            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
               == 1
           "for": "15m"
           "labels":
@@ -356,9 +356,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
             "summary": "Namespace quota has exceeded the limits."
           "expr": |
-            kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="used"}
+            kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics", type="hard"} > 0)
               > 1
           "for": "15m"
           "labels":
@@ -387,16 +387,16 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -408,18 +408,18 @@ spec:
             "summary": "PersistentVolume is filling up."
           "expr": |
             (
-              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_capacity_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+            kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -431,16 +431,16 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
             ) < 0.03
             and
-            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
             "severity": "critical"
@@ -452,18 +452,18 @@ spec:
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
             (
-              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
                 /
-              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|kube.*",job="kubelet"}
+              kubelet_volume_stats_inodes{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}
             ) < 0.15
             and
-            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|kube.*",job="kubelet"} > 0
+            kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"} > 0
             and
-            predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|kube.*", access_mode="ReadOnlyMany"} == 1
+            kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-marketplace|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(namespace, persistentvolumeclaim)
-            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|kube.*",label_excluded_from_alerts="true"} == 1
+            kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-marketplace|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
             "severity": "warning"
@@ -474,7 +474,7 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
             "summary": "PersistentVolume is having issues with provisioning."
           "expr": |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|kube.*",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace!~"openshift-kube.*|openshift-marketplace|kube.*",job="kube-state-metrics"} > 0
           "for": "5m"
           "labels":
             "severity": "critical"


### PR DESCRIPTION
# Description

Increasing the area of ignored alerts due to some unwanted pages for the `openshift-marketplace` namespace (in this case the `community-operator` pod).

_Note for reviewers: unsure why there are so many changes within the dashboard after running `make generate`._
