### PR TITLE
fix(alerts): ignore CPU throttling for `openshift-*`

### DIFF
--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -363,9 +363,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
       "summary": "Processes experience elevated CPU throttling."
     "expr": |
-      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
         /
-      sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
         > ( 25 / 100 )
     "for": "15m"
     "labels":

--- a/resources/mixins/kubernetes/jsonnetfile.lock.json
+++ b/resources/mixins/kubernetes/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "c0d0a133a88a1a1b0729525d0269e861a28ce09a",
+      "version": "672dec488b8126ba10b80f221a876735bcda2549",
       "sum": "xEFMv4+ObwP5L1Wu0XK5agWci4AJzNApys6iKAQxLlQ="
     },
     {

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -5,11 +5,12 @@ kubernetes {
   _config+:: {
     cadvisorSelector: 'job="kubelet",metrics_path="/metrics/cadvisor"',
     containerfsSelector: 'id!=""',
-    grafanaIntervalVar: "5m",
+    cpuThrottlingSelector: 'namespace!~"openshift-.*',
+    grafanaIntervalVar: '5m',
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',
     kubeSchedulerSelector: 'job="scheduler"',
-    namespaceSelector: 'namespace!~"openshift-kube.*|openshift-marketplace|openshift-deployment.*|kube.*"'
+    namespaceSelector: 'namespace!~"openshift-kube.*|openshift-marketplace|openshift-deployment.*|kube.*"',
   },
 } + {
   // Customize alert labels.

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -370,9 +370,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
             "summary": "Processes experience elevated CPU throttling."
           "expr": |
-            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
               /
-            sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
               > ( 25 / 100 )
           "for": "15m"
           "labels":


### PR DESCRIPTION
The changes in #125 are not sufficient to suppress CPU throttling alerts because the mixin uses a separate `cpuThrottlingSelector` for the CPU throttling alerts. This change now ignores CPU throttling explicitly for all `openshift-.*` namespaces.