### PR TITLE
fix(makefile): separate `generate` and `update` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: generate
 generate:
 	$(MAKE) -C resources/mixins/kubernetes generate
+
+.PHONY: update
+update:
+	$(MAKE) -C resources/mixins/kubernetes update

--- a/resources/mixins/kubernetes/Makefile
+++ b/resources/mixins/kubernetes/Makefile
@@ -1,5 +1,8 @@
 .PHONY: update
-update:
+update: update-jb generate
+
+.PHONY: update-jb
+update-jb:
 	@jb update
 
 .PHONY: alerts
@@ -13,4 +16,4 @@ dashboards: templates/dashboards/*
 	@scripts/generate-dashboards.sh
 
 .PHONY: generate
-generate: update alerts dashboards
+generate: alerts dashboards

--- a/resources/mixins/kubernetes/README.md
+++ b/resources/mixins/kubernetes/README.md
@@ -9,7 +9,7 @@ The Kubernetes mixin requires jsonnet to render its output resources:
 
 ## Update
 
-Execute `make generate` to update the mixin and re-generate all resources.
+Execute `make update` to update the mixin and re-generate all resources.
 
 ## OpenShift platform metrics federation
 


### PR DESCRIPTION
Separate `generate` and `update` from each other, such that one can regenerate the mixins without also having to update their revision.