### PR TITLE
fix(mixins): typo in cpu throttle selector

### DIFF
--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -363,9 +363,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
       "summary": "Processes experience elevated CPU throttling."
     "expr": |
-      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
         /
-      sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
         > ( 25 / 100 )
     "for": "15m"
     "labels":

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -5,7 +5,7 @@ kubernetes {
   _config+:: {
     cadvisorSelector: 'job="kubelet",metrics_path="/metrics/cadvisor"',
     containerfsSelector: 'id!=""',
-    cpuThrottlingSelector: 'namespace!~"openshift-.*',
+    cpuThrottlingSelector: 'namespace!~"openshift-.*"',
     grafanaIntervalVar: '5m',
     kubeApiserverSelector: 'job="api"',
     kubeProxySelector: 'job="machine-config-daemon"',

--- a/resources/prometheus/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/kubernetes-mixin-alerts.yaml
@@ -370,9 +370,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
             "summary": "Processes experience elevated CPU throttling."
           "expr": |
-            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
               /
-            sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
               > ( 25 / 100 )
           "for": "15m"
           "labels":


### PR DESCRIPTION
Fix a typo in the selector string - missing a `"` to terminate correctly.

See #133 for fixing the pre-commit hook in CI.