### PR TITLE
chore(pre-commit): update deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.5
     hooks:
       - id: shellcheck
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-json


### PR DESCRIPTION
The old versions seem to break the pre-commit hook on master, see https://github.com/stackrox/rhacs-observability-resources/actions/runs/5861091004/job/15890846319. Updating to the latest versions seems to fix it.