### PR TITLE
fix(metrics): consider PingService in SLI

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -353,12 +353,12 @@ spec:
         # GRPC
         - expr: |
             sum by (namespace, rhacs_instance_id, rhacs_org_id, rhacs_org_name, rhacs_cluster_name, rhacs_environment)
-            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_service!="v1.PingService", grpc_code!~"DeadlineExceeded|Internal|Unavailable|Unknown"}[10m]))
+            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_code!~"DeadlineExceeded|Internal|Unavailable|Unknown"}[10m]))
           record: central:grpc_server_handled:server_available_code:rate10m
 
         - expr: |
             sum by (namespace, rhacs_instance_id, rhacs_org_id, rhacs_org_name, rhacs_cluster_name, rhacs_environment)
-            (rate(grpc_server_started_total{namespace=~"rhacs-.*", job="central", grpc_type="unary",grpc_service!="v1.PingService"}[10m]))
+            (rate(grpc_server_started_total{namespace=~"rhacs-.*", job="central", grpc_type="unary"}[10m]))
           record: central:grpc_server_started:total:rate10m
 
         # HTTP


### PR DESCRIPTION
Add internal requests via the PingService to the request count considered in error rate SLI. For reference, the PingService adds a baseline of 1 request every 10 seconds.

* (+) SLI are more stable because of a higher base of requests. Especially relevant when Central is essentially idling, because then a small number of failed requests may trigger the SLI. See https://redhat-internal.slack.com/archives/C05LSCJCRMY for an example of this.
* (-) This is also masking real failures with non-relevant internal requests.