### PR TITLE
refactor(metrics): use prom bool comparison

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -412,8 +412,8 @@ spec:
         # We keep the `namespace` and `rhacs_instance_id` labels to be consistent with other SLI metrics and for
         # reference in dashboards.
         - expr: |
-            sum by (namespace, rhacs_instance_id) (
-                floor (central:success_rate10m + 0.35)
+            max by (namespace, rhacs_instance_id) (
+                central:success_rate10m > bool 0.65
             )
             or on (namespace, rhacs_instance_id) central:sli:pod_ready
           record: central:sli:error_rate


### PR DESCRIPTION
Small refactoring of the promQL query to make it more promQL idiomatic.

* `sum` -> `max`: Both are equivalent here because we are summing/maxing over a single value. However `max` shows the intention more clearly imo.
* `floor` -> `> bool`: This does the same thing, but `> bool` is the promQL native way to perform the floor.