### PR TITLE
no federation of central platform metrics

### DIFF
--- a/resources/prometheus/federation-config.yaml
+++ b/resources/prometheus/federation-config.yaml
@@ -1,3 +1,4 @@
 match[]:
-  # Federate all metrics to obtain all metrics for the Kubernetes mixin.
-  - '{__name__=~".*"}'
+  # Federate all platform metrics except ACS metrics. We want all base metrics for the Kubernetes mixin.
+  - '{__name__=~".*", job!="central"}'
+  - '{__name__=~".*", job="central", endpoint!="monitoring-tls"}'


### PR DESCRIPTION
Central integrates now with OpenShift platform prometheus. As such, we need to exclude these metrics from the platform metrics federation to prevent double counting.