### PR TITLE
fix(sli): allow `Unknown` status code in SLI error rate

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -351,9 +351,10 @@ spec:
         # The error rate over the last 10 minutes must be smaller than 35% to count as available.
 
         # GRPC
+        # TODO(ROX-19917): Re-add `grpc_code="Unknown"` to the list of server errors.
         - expr: |
             sum by (namespace, rhacs_instance_id, rhacs_org_id, rhacs_org_name, rhacs_cluster_name, rhacs_environment)
-            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_service!="v1.PingService", grpc_code!~"DeadlineExceeded|Internal|Unavailable|Unknown"}[10m]))
+            (rate(grpc_server_handled_total{namespace=~"rhacs-.*", job="central", grpc_type="unary", grpc_service!="v1.PingService", grpc_code!~"DeadlineExceeded|Internal|Unavailable"}[10m]))
           record: central:grpc_server_handled:server_available_code:rate10m
 
         - expr: |


### PR DESCRIPTION
This is a workaround to the SLO issue observed in https://issues.redhat.com/browse/ROX-19887.
In short, due to flawed ordering of gRPC interceptors in Central, client errors were counted as `Unknown` gRPC codes in Prometheus metrics. To protect our SLO metrics from ballooning out of control, we temporarily not count `Unknown` errors as server errors.

This is to be reverted again once https://github.com/stackrox/stackrox/pull/7942 is released and deployed to production. See https://issues.redhat.com/browse/ROX-19917 for the task to do exactly that.