### PR TITLE
chore: bump grafana version to 10.2.0

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -48,7 +48,7 @@
         "grafana/generated/dashboards/rhacs-central-slo-dashboard.yaml",
         "grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml"
       ],
-      "grafanaVersion": "9.4.7"
+      "grafanaVersion": "10.2.0"
     },
     "promtail": {
       "enabled": false,


### PR DESCRIPTION
Includes base image upgrades and CVE fixes. I skimmed the breaking changes introduced with 10.x (https://grafana.com/docs/grafana/latest/breaking-changes/breaking-changes-v10-0/) and did not notice anything that would affect us. So I think it's safe to merge and test on integration env.