### PR TITLE
ROX-20385: Slack notification workflow

### DIFF
--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -1,0 +1,22 @@
+name: Notify on push to production
+on:
+  push:
+    branches: ['production']
+
+jobs:
+  slack:
+    name: Slack
+    runs-on: ubuntu-latest
+    steps:
+    - name: Post to Slack about push to production
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }} 
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: 'C04CV2JKV16' #forum-acs-cs-release
+        payload: >-
+          { "text":
+          ":warning: <${{ github.event.compare }}|Something>
+          has been pushed to the `${{ github.ref_name }}` branch of
+          <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>."
+          }

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Post to Slack about push to production
       env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }} 
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       uses: slackapi/slack-github-action@v1.24.0
       with:
         channel-id: 'C04CV2JKV16' #forum-acs-cs-release


### PR DESCRIPTION
Post a notification to Slack about any push to production, so that release engineers are aware.

Test workflow run: https://github.com/stackrox/test-gh-actions/actions/runs/6691295752
Resulting message in the test channel: https://redhat-internal.slack.com/archives/C03KSV3N6N8/p1698660800307679