### PR TITLE
fix cluster resource template file names

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-cluster-resource-adjustment-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-resource-adjustment-configmap.yaml
@@ -1,13 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDashboard
+apiVersion: v1
+kind: ConfigMap
 metadata:
+  creationTimestamp: null
+  name: rhacs-cluster-resource-adjustment
   labels:
-    app: rhacs
-    monitoring-key: middleware
-  name: rhacs-cluster-resource-adjustment-dashboard
-  namespace: <namespace>
-spec:
-  name: rhacs-cluster-resource-adjustment.json
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Addons
+data:
   json: |
     {
       "annotations": {

--- a/resources/grafana/generated/dashboards/rhacs-cluster-resource-adjustment-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-resource-adjustment-dashboard.yaml
@@ -1,13 +1,13 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
 metadata:
-  creationTimestamp: null
-  name: rhacs-cluster-resource-adjustment
   labels:
-    grafana_dashboard: "true"
-  annotations:
-    grafana-folder: /grafana-dashboard-definitions/Addons
-data:
+    app: rhacs
+    monitoring-key: middleware
+  name: rhacs-cluster-resource-adjustment-dashboard
+  namespace: <namespace>
+spec:
+  name: rhacs-cluster-resource-adjustment.json
   json: |
     {
       "annotations": {

--- a/resources/grafana/templates/dashboards/rhacs-cluster-resource-adjustment-configmap.yaml
+++ b/resources/grafana/templates/dashboards/rhacs-cluster-resource-adjustment-configmap.yaml
@@ -1,11 +1,11 @@
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDashboard
+apiVersion: v1
+kind: ConfigMap
 metadata:
+  creationTimestamp: null
+  name: rhacs-cluster-resource-adjustment
   labels:
-    app: rhacs
-    monitoring-key: middleware
-  name: rhacs-cluster-resource-adjustment-dashboard
-  namespace: <namespace>
-spec:
-  name: rhacs-cluster-resource-adjustment.json
+    grafana_dashboard: "true"
+  annotations:
+    grafana-folder: /grafana-dashboard-definitions/Addons
+data:
   json: |

--- a/resources/grafana/templates/dashboards/rhacs-cluster-resource-adjustment-dashboard.yaml
+++ b/resources/grafana/templates/dashboards/rhacs-cluster-resource-adjustment-dashboard.yaml
@@ -1,11 +1,11 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
 metadata:
-  creationTimestamp: null
-  name: rhacs-cluster-resource-adjustment
   labels:
-    grafana_dashboard: "true"
-  annotations:
-    grafana-folder: /grafana-dashboard-definitions/Addons
-data:
+    app: rhacs
+    monitoring-key: middleware
+  name: rhacs-cluster-resource-adjustment-dashboard
+  namespace: <namespace>
+spec:
+  name: rhacs-cluster-resource-adjustment.json
   json: |


### PR DESCRIPTION
Accidentally mixed up the `ConfigMap` and `GrafanaDashboard` resources in #158.