### PR TITLE
feat: add `make generate` to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
       - id: end-of-file-fixer
   - repo: local
     hooks:
+      - id: make-generate
+        name: make generate
+        entry: ./scripts/run-make-generate.sh
+        language: system
+        pass_filenames: false
       - id: grafana-lint
         name: grafana lint
         entry: ./scripts/lint-grafana.sh

--- a/scripts/run-make-generate.sh
+++ b/scripts/run-make-generate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if ! [ -x "$(command -v jb)" ]; then
+	go install -a github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
+fi
+
+if ! [ -x "$(command -v jsonnet)" ]; then
+	go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+fi
+
+if ! [ -x "$(command -v yq)" ]; then
+	go install github.com/mikefarah/yq/v4@latest
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" &>/dev/null && pwd 2>/dev/null)"
+
+make -C "$SCRIPT_DIR"/.. generate


### PR DESCRIPTION
Run `make generate` as part of the pre-commit hook. It should fail if there is anything modified, i.e. if there was anything generated.