### PR TITLE
chore: make SLI graphs more readable

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-central-slo-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-central-slo-configmap.yaml
@@ -35,7 +35,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 7,
+      "id": 15,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -61,7 +61,7 @@ data:
     		"content": "## Definition\n\nThe availability of Central is defined as a combination of pod ready status and API error rate.\n\n`Availability SLI = Pod Ready SLI * Error Rate SLI`\n\nThe SLO target is 99% availability calculated over 28 day rolling intervals.",
     		"mode": "markdown"
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "type": "text"
     	},
     	{
@@ -88,6 +88,7 @@ data:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -101,6 +102,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -460,6 +462,7 @@ data:
     	  },
     	  "id": 18,
     	  "options": {
+    		"cellHeight": "sm",
     		"footer": {
     		  "countRows": false,
     		  "enablePagination": true,
@@ -472,7 +475,7 @@ data:
     		"showHeader": true,
     		"sortBy": []
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -640,7 +643,7 @@ data:
     		"uid": "PBFA97CFB590B2093"
     	  },
     	  "gridPos": {
-    		"h": 2,
+    		"h": 3,
     		"w": 23,
     		"x": 0,
     		"y": 32
@@ -652,10 +655,10 @@ data:
     		  "showLineNumbers": false,
     		  "showMiniMap": false
     		},
-    		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.",
+    		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.\n\nWe plot a proxy of the SLI based on the number of unavailability drops per hour (percentage gauges are exact). This renders better in Grafana for long ranges. Note that the actual down time may be shorter than is rendered. It might still be necessary to zoom in around burn rate spikes to get full resolution.",
     		"mode": "markdown"
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "type": "text"
     	},
     	{
@@ -698,10 +701,12 @@ data:
     		"h": 8,
     		"w": 5,
     		"x": 0,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 6,
     	  "options": {
+    		"minVizHeight": 75,
+    		"minVizWidth": 75,
     		"orientation": "auto",
     		"reduceOptions": {
     		  "calcs": [
@@ -713,7 +718,7 @@ data:
     		"showThresholdLabels": false,
     		"showThresholdMarkers": true
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -735,13 +740,14 @@ data:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`Pod Ready SLI * Error Rate SLI`",
+    	  "description": "`Pod Ready SLI * Error Rate SLI`\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -755,6 +761,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -794,7 +801,7 @@ data:
     		"h": 8,
     		"w": 6,
     		"x": 5,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 9,
     	  "options": {
@@ -816,7 +823,7 @@ data:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:availability{rhacs_instance_id=~\"$instance_id\"})",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:availability{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
     		  "legendFormat": "{{label_name}}",
     		  "range": true,
     		  "refId": "A"
@@ -830,13 +837,14 @@ data:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`1` is at least one pod is in ready state. `0` otherwise.",
+    	  "description": "`1` is at least one pod is in ready state. `0` otherwise.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -850,6 +858,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -889,7 +898,7 @@ data:
     		"h": 8,
     		"w": 6,
     		"x": 11,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 13,
     	  "options": {
@@ -911,8 +920,8 @@ data:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"})",
-    		  "legendFormat": "{{label_name}}",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
+    		  "legendFormat": "SLI",
     		  "range": true,
     		  "refId": "A"
     		}
@@ -925,13 +934,14 @@ data:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.",
+    	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -945,6 +955,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -984,7 +995,7 @@ data:
     		"h": 8,
     		"w": 6,
     		"x": 17,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 12,
     	  "options": {
@@ -1006,7 +1017,7 @@ data:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:error_rate{rhacs_instance_id=~\"$instance_id\"})",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:error_rate{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
     		  "legendFormat": "{{label_name}}",
     		  "range": true,
     		  "refId": "A"
@@ -1060,10 +1071,12 @@ data:
     		"h": 8,
     		"w": 5,
     		"x": 0,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 7,
     	  "options": {
+    		"minVizHeight": 75,
+    		"minVizWidth": 75,
     		"orientation": "auto",
     		"reduceOptions": {
     		  "calcs": [
@@ -1075,7 +1088,7 @@ data:
     		"showThresholdLabels": false,
     		"showThresholdMarkers": true
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -1103,6 +1116,7 @@ data:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -1116,6 +1130,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -1154,7 +1169,7 @@ data:
     		"h": 8,
     		"w": 9,
     		"x": 5,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 10,
     	  "options": {
@@ -1196,6 +1211,7 @@ data:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -1209,6 +1225,7 @@ data:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -1247,7 +1264,7 @@ data:
     		"h": 8,
     		"w": 9,
     		"x": 14,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 14,
     	  "options": {
@@ -1279,10 +1296,9 @@ data:
     	  "type": "timeseries"
     	}
       ],
-      "refresh": "",
+      "refresh": false,
       "revision": 1,
-      "schemaVersion": 37,
-      "style": "dark",
+      "schemaVersion": 38,
       "tags": [
     	"rhacs"
       ],
@@ -1439,6 +1455,6 @@ data:
       "timezone": "",
       "title": "RHACS Dataplane - Central SLOs",
       "uid": "vH7ntMs4k",
-      "version": 2,
+      "version": 1,
       "weekStart": ""
     }

--- a/resources/grafana/generated/dashboards/rhacs-central-slo-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-central-slo-dashboard.yaml
@@ -35,7 +35,7 @@ spec:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 7,
+      "id": 15,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -61,7 +61,7 @@ spec:
     		"content": "## Definition\n\nThe availability of Central is defined as a combination of pod ready status and API error rate.\n\n`Availability SLI = Pod Ready SLI * Error Rate SLI`\n\nThe SLO target is 99% availability calculated over 28 day rolling intervals.",
     		"mode": "markdown"
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "type": "text"
     	},
     	{
@@ -88,6 +88,7 @@ spec:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -101,6 +102,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -460,6 +462,7 @@ spec:
     	  },
     	  "id": 18,
     	  "options": {
+    		"cellHeight": "sm",
     		"footer": {
     		  "countRows": false,
     		  "enablePagination": true,
@@ -472,7 +475,7 @@ spec:
     		"showHeader": true,
     		"sortBy": []
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -640,7 +643,7 @@ spec:
     		"uid": "PBFA97CFB590B2093"
     	  },
     	  "gridPos": {
-    		"h": 2,
+    		"h": 3,
     		"w": 23,
     		"x": 0,
     		"y": 32
@@ -652,10 +655,10 @@ spec:
     		  "showLineNumbers": false,
     		  "showMiniMap": false
     		},
-    		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.",
+    		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.\n\nWe plot a proxy of the SLI based on the number of unavailability drops per hour (percentage gauges are exact). This renders better in Grafana for long ranges. Note that the actual down time may be shorter than is rendered. It might still be necessary to zoom in around burn rate spikes to get full resolution.",
     		"mode": "markdown"
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "type": "text"
     	},
     	{
@@ -698,10 +701,12 @@ spec:
     		"h": 8,
     		"w": 5,
     		"x": 0,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 6,
     	  "options": {
+    		"minVizHeight": 75,
+    		"minVizWidth": 75,
     		"orientation": "auto",
     		"reduceOptions": {
     		  "calcs": [
@@ -713,7 +718,7 @@ spec:
     		"showThresholdLabels": false,
     		"showThresholdMarkers": true
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -735,13 +740,14 @@ spec:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`Pod Ready SLI * Error Rate SLI`",
+    	  "description": "`Pod Ready SLI * Error Rate SLI`\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -755,6 +761,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -794,7 +801,7 @@ spec:
     		"h": 8,
     		"w": 6,
     		"x": 5,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 9,
     	  "options": {
@@ -816,7 +823,7 @@ spec:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:availability{rhacs_instance_id=~\"$instance_id\"})",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:availability{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
     		  "legendFormat": "{{label_name}}",
     		  "range": true,
     		  "refId": "A"
@@ -830,13 +837,14 @@ spec:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`1` is at least one pod is in ready state. `0` otherwise.",
+    	  "description": "`1` is at least one pod is in ready state. `0` otherwise.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -850,6 +858,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -889,7 +898,7 @@ spec:
     		"h": 8,
     		"w": 6,
     		"x": 11,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 13,
     	  "options": {
@@ -911,8 +920,8 @@ spec:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"})",
-    		  "legendFormat": "{{label_name}}",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
+    		  "legendFormat": "SLI",
     		  "range": true,
     		  "refId": "A"
     		}
@@ -925,13 +934,14 @@ spec:
     		"type": "prometheus",
     		"uid": "PBFA97CFB590B2093"
     	  },
-    	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.",
+    	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
     	  "fieldConfig": {
     		"defaults": {
     		  "color": {
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -945,6 +955,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -984,7 +995,7 @@ spec:
     		"h": 8,
     		"w": 6,
     		"x": 17,
-    		"y": 34
+    		"y": 35
     	  },
     	  "id": 12,
     	  "options": {
@@ -1006,7 +1017,7 @@ spec:
     			"uid": "PBFA97CFB590B2093"
     		  },
     		  "editorMode": "code",
-    		  "expr": "avg(central:sli:error_rate{rhacs_instance_id=~\"$instance_id\"})",
+    		  "expr": "1 - clamp_max(avg(changes(central:sli:error_rate{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
     		  "legendFormat": "{{label_name}}",
     		  "range": true,
     		  "refId": "A"
@@ -1060,10 +1071,12 @@ spec:
     		"h": 8,
     		"w": 5,
     		"x": 0,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 7,
     	  "options": {
+    		"minVizHeight": 75,
+    		"minVizWidth": 75,
     		"orientation": "auto",
     		"reduceOptions": {
     		  "calcs": [
@@ -1075,7 +1088,7 @@ spec:
     		"showThresholdLabels": false,
     		"showThresholdMarkers": true
     	  },
-    	  "pluginVersion": "9.4.7",
+    	  "pluginVersion": "10.2.0",
     	  "targets": [
     		{
     		  "datasource": {
@@ -1103,6 +1116,7 @@ spec:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -1116,6 +1130,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -1154,7 +1169,7 @@ spec:
     		"h": 8,
     		"w": 9,
     		"x": 5,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 10,
     	  "options": {
@@ -1196,6 +1211,7 @@ spec:
     			"mode": "palette-classic"
     		  },
     		  "custom": {
+    			"axisBorderShow": false,
     			"axisCenteredZero": false,
     			"axisColorMode": "text",
     			"axisLabel": "",
@@ -1209,6 +1225,7 @@ spec:
     			  "tooltip": false,
     			  "viz": false
     			},
+    			"insertNulls": false,
     			"lineInterpolation": "linear",
     			"lineWidth": 1,
     			"pointSize": 5,
@@ -1247,7 +1264,7 @@ spec:
     		"h": 8,
     		"w": 9,
     		"x": 14,
-    		"y": 42
+    		"y": 43
     	  },
     	  "id": 14,
     	  "options": {
@@ -1279,10 +1296,9 @@ spec:
     	  "type": "timeseries"
     	}
       ],
-      "refresh": "",
+      "refresh": false,
       "revision": 1,
-      "schemaVersion": 37,
-      "style": "dark",
+      "schemaVersion": 38,
       "tags": [
     	"rhacs"
       ],
@@ -1439,6 +1455,6 @@ spec:
       "timezone": "",
       "title": "RHACS Dataplane - Central SLOs",
       "uid": "vH7ntMs4k",
-      "version": 2,
+      "version": 1,
       "weekStart": ""
     }

--- a/resources/grafana/sources/rhacs-central-slo.json
+++ b/resources/grafana/sources/rhacs-central-slo.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 7,
+  "id": 15,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -50,7 +50,7 @@
 		"content": "## Definition\n\nThe availability of Central is defined as a combination of pod ready status and API error rate.\n\n`Availability SLI = Pod Ready SLI * Error Rate SLI`\n\nThe SLO target is 99% availability calculated over 28 day rolling intervals.",
 		"mode": "markdown"
 	  },
-	  "pluginVersion": "9.4.7",
+	  "pluginVersion": "10.2.0",
 	  "type": "text"
 	},
 	{
@@ -77,6 +77,7 @@
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -90,6 +91,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -449,6 +451,7 @@
 	  },
 	  "id": 18,
 	  "options": {
+		"cellHeight": "sm",
 		"footer": {
 		  "countRows": false,
 		  "enablePagination": true,
@@ -461,7 +464,7 @@
 		"showHeader": true,
 		"sortBy": []
 	  },
-	  "pluginVersion": "9.4.7",
+	  "pluginVersion": "10.2.0",
 	  "targets": [
 		{
 		  "datasource": {
@@ -629,7 +632,7 @@
 		"uid": "PBFA97CFB590B2093"
 	  },
 	  "gridPos": {
-		"h": 2,
+		"h": 3,
 		"w": 23,
 		"x": 0,
 		"y": 32
@@ -641,10 +644,10 @@
 		  "showLineNumbers": false,
 		  "showMiniMap": false
 		},
-		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.",
+		"content": "Select instances via the variables on top of the dashbord. If multiple Centrals are selected, the SLIs/SLOs are averaged.\n\nWe plot a proxy of the SLI based on the number of unavailability drops per hour (percentage gauges are exact). This renders better in Grafana for long ranges. Note that the actual down time may be shorter than is rendered. It might still be necessary to zoom in around burn rate spikes to get full resolution.",
 		"mode": "markdown"
 	  },
-	  "pluginVersion": "9.4.7",
+	  "pluginVersion": "10.2.0",
 	  "type": "text"
 	},
 	{
@@ -687,10 +690,12 @@
 		"h": 8,
 		"w": 5,
 		"x": 0,
-		"y": 34
+		"y": 35
 	  },
 	  "id": 6,
 	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
 		"orientation": "auto",
 		"reduceOptions": {
 		  "calcs": [
@@ -702,7 +707,7 @@
 		"showThresholdLabels": false,
 		"showThresholdMarkers": true
 	  },
-	  "pluginVersion": "9.4.7",
+	  "pluginVersion": "10.2.0",
 	  "targets": [
 		{
 		  "datasource": {
@@ -724,13 +729,14 @@
 		"type": "prometheus",
 		"uid": "PBFA97CFB590B2093"
 	  },
-	  "description": "`Pod Ready SLI * Error Rate SLI`",
+	  "description": "`Pod Ready SLI * Error Rate SLI`\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
 	  "fieldConfig": {
 		"defaults": {
 		  "color": {
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -744,6 +750,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -783,7 +790,7 @@
 		"h": 8,
 		"w": 6,
 		"x": 5,
-		"y": 34
+		"y": 35
 	  },
 	  "id": 9,
 	  "options": {
@@ -805,7 +812,7 @@
 			"uid": "PBFA97CFB590B2093"
 		  },
 		  "editorMode": "code",
-		  "expr": "avg(central:sli:availability{rhacs_instance_id=~\"$instance_id\"})",
+		  "expr": "1 - clamp_max(avg(changes(central:sli:availability{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
 		  "legendFormat": "{{label_name}}",
 		  "range": true,
 		  "refId": "A"
@@ -819,13 +826,14 @@
 		"type": "prometheus",
 		"uid": "PBFA97CFB590B2093"
 	  },
-	  "description": "`1` is at least one pod is in ready state. `0` otherwise.",
+	  "description": "`1` is at least one pod is in ready state. `0` otherwise.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
 	  "fieldConfig": {
 		"defaults": {
 		  "color": {
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -839,6 +847,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -878,7 +887,7 @@
 		"h": 8,
 		"w": 6,
 		"x": 11,
-		"y": 34
+		"y": 35
 	  },
 	  "id": 13,
 	  "options": {
@@ -900,8 +909,8 @@
 			"uid": "PBFA97CFB590B2093"
 		  },
 		  "editorMode": "code",
-		  "expr": "avg(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"})",
-		  "legendFormat": "{{label_name}}",
+		  "expr": "1 - clamp_max(avg(changes(central:sli:pod_ready{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
+		  "legendFormat": "SLI",
 		  "range": true,
 		  "refId": "A"
 		}
@@ -914,13 +923,14 @@
 		"type": "prometheus",
 		"uid": "PBFA97CFB590B2093"
 	  },
-	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.",
+	  "description": "`1` if the combined error rate of gRPC and HTTP requests is `<35%`. `0` otherwise.\n\nA gRPC error is defined by a response with `grpc_code != OK`. An HTTP error is defined by a response with status code `5xx`.\n\nWe show a proxy of the SLI based on the number of unavailability drops because it renders better in Grafana.",
 	  "fieldConfig": {
 		"defaults": {
 		  "color": {
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -934,6 +944,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -973,7 +984,7 @@
 		"h": 8,
 		"w": 6,
 		"x": 17,
-		"y": 34
+		"y": 35
 	  },
 	  "id": 12,
 	  "options": {
@@ -995,7 +1006,7 @@
 			"uid": "PBFA97CFB590B2093"
 		  },
 		  "editorMode": "code",
-		  "expr": "avg(central:sli:error_rate{rhacs_instance_id=~\"$instance_id\"})",
+		  "expr": "1 - clamp_max(avg(changes(central:sli:error_rate{namespace=~\"rhacs-$instance_id\"}[1h])), 1)",
 		  "legendFormat": "{{label_name}}",
 		  "range": true,
 		  "refId": "A"
@@ -1049,10 +1060,12 @@
 		"h": 8,
 		"w": 5,
 		"x": 0,
-		"y": 42
+		"y": 43
 	  },
 	  "id": 7,
 	  "options": {
+		"minVizHeight": 75,
+		"minVizWidth": 75,
 		"orientation": "auto",
 		"reduceOptions": {
 		  "calcs": [
@@ -1064,7 +1077,7 @@
 		"showThresholdLabels": false,
 		"showThresholdMarkers": true
 	  },
-	  "pluginVersion": "9.4.7",
+	  "pluginVersion": "10.2.0",
 	  "targets": [
 		{
 		  "datasource": {
@@ -1092,6 +1105,7 @@
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -1105,6 +1119,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -1143,7 +1158,7 @@
 		"h": 8,
 		"w": 9,
 		"x": 5,
-		"y": 42
+		"y": 43
 	  },
 	  "id": 10,
 	  "options": {
@@ -1185,6 +1200,7 @@
 			"mode": "palette-classic"
 		  },
 		  "custom": {
+			"axisBorderShow": false,
 			"axisCenteredZero": false,
 			"axisColorMode": "text",
 			"axisLabel": "",
@@ -1198,6 +1214,7 @@
 			  "tooltip": false,
 			  "viz": false
 			},
+			"insertNulls": false,
 			"lineInterpolation": "linear",
 			"lineWidth": 1,
 			"pointSize": 5,
@@ -1236,7 +1253,7 @@
 		"h": 8,
 		"w": 9,
 		"x": 14,
-		"y": 42
+		"y": 43
 	  },
 	  "id": 14,
 	  "options": {
@@ -1268,10 +1285,9 @@
 	  "type": "timeseries"
 	}
   ],
-  "refresh": "",
+  "refresh": false,
   "revision": 1,
-  "schemaVersion": 37,
-  "style": "dark",
+  "schemaVersion": 38,
   "tags": [
 	"rhacs"
   ],
@@ -1428,6 +1444,6 @@
   "timezone": "",
   "title": "RHACS Dataplane - Central SLOs",
   "uid": "vH7ntMs4k",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Make the SLI graphs more readable by showing a proxy that renders better in Grafana. The problem right now is that Grafana swallows up spikes and instead renders a flat line. The proxy metric works by extending the "downtime" interval via `changes(...[1h])`, such that Grafana has an easier way rendering it. The downside is that downtimes may appear longer than they were - however, the overall percentages (9' notation) are still exact.

Before:
<img width="1451" alt="Screenshot 2023-12-12 at 21 07 02" src="https://github.com/stackrox/rhacs-observability-resources/assets/55607356/4285387e-0fcf-44d0-93c3-8bb50c6f6ddf">

After:
<img width="1451" alt="Screenshot 2023-12-12 at 21 06 55" src="https://github.com/stackrox/rhacs-observability-resources/assets/55607356/fa2710ef-e01f-4029-a0e4-ad72c83a39ae">

The dashboard can be viewed temporarily under https://grafana-route-rhacs-observability.apps.acs-prod-dp-01.pnz3.p1.openshiftapps.com/d/a3d89363-95c2-470f-82d8-cd9c62fe3840/rhacs-dataplane-central-slos-copy?orgId=1.