### PR TITLE
chore: tighten tenant memory alerts

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -172,7 +172,7 @@ spec:
           record: rhacs_tenants:namespace:pod:container:max_memory_usage_ratio
         - alert: RHACSTenantWorkloadMemoryUtilizationHigh
           expr: |
-            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio >= 0.75
+            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio{container="central"} >= 0.85
           for: 10m
           labels:
             severity: warning
@@ -182,7 +182,7 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-039-tenant-workload-memory-utilization-high.md"
         - alert: RHACSTenantWorkloadMemoryUtilizationCritical
           expr: |
-            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio >= 0.9
+            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio{container="central"} >= 0.95
           for: 10m
           labels:
             severity: critical

--- a/resources/prometheus/unit_tests/RHACSTenantWorkloadMemoryUtilizationHigh.yaml
+++ b/resources/prometheus/unit_tests/RHACSTenantWorkloadMemoryUtilizationHigh.yaml
@@ -6,9 +6,9 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: container_memory_working_set_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa", pod="mypod", container="container-1"}
-        values: "50+0x10 75+0x10"
-      - series: container_spec_memory_limit_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod", container="container-1"}
+      - series: container_memory_working_set_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa", pod="mypod", container="central"}
+        values: "50+0x10 85+0x10"
+      - series: container_spec_memory_limit_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod", container="central"}
         values: "100+0x20"
     alert_rule_test:
       - eval_time: 1m
@@ -22,16 +22,16 @@ tests:
               severity: warning
               namespace: rhacs-aaaaaaaaaaaaaaaaaaaa
               pod: mypod
-              container: container-1
+              container: central
             exp_annotations:
-              summary: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'container-1' in pod 'mypod' is reaching its memory limit.
-              description: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'container-1' in pod 'mypod' reached 75% of its memory limit and is at risk of being OOM killed.
+              summary: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'central' in pod 'mypod' is reaching its memory limit.
+              description: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'central' in pod 'mypod' reached 85% of its memory limit and is at risk of being OOM killed.
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-039-tenant-workload-memory-utilization-high.md"
   - interval: 1m
     input_series:
-      - series: container_memory_working_set_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="container-1"}
-        values: "50+0x10 90+0x10"
-      - series: container_spec_memory_limit_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="container-1"}
+      - series: container_memory_working_set_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="central"}
+        values: "50+0x10 95+0x10"
+      - series: container_spec_memory_limit_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="central"}
         values: "100+0x20"
     alert_rule_test:
       - eval_time: 1m
@@ -45,8 +45,19 @@ tests:
               severity: critical
               namespace: rhacs-aaaaaaaaaaaaaaaaaaaa
               pod: mypod
-              container: container-1
+              container: central
             exp_annotations:
-              description: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'container-1' in pod 'mypod' reached 90% of its memory limit and is at high risk of being OOM killed.
-              summary: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'container-1' in pod 'mypod' is critically reaching its memory limit.
+              description: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'central' in pod 'mypod' reached 95% of its memory limit and is at high risk of being OOM killed.
+              summary: tenant 'rhacs-aaaaaaaaaaaaaaaaaaaa' container 'central' in pod 'mypod' is critically reaching its memory limit.
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-039-tenant-workload-memory-utilization-high.md"
+  # scanner memory usage does not alert
+  - interval: 1m
+    input_series:
+      - series: container_memory_working_set_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="scanner"}
+        values: "50+0x10 95+0x10"
+      - series: container_spec_memory_limit_bytes{namespace="rhacs-aaaaaaaaaaaaaaaaaaaa",pod="mypod",container="scanner"}
+        values: "100+0x20"
+    alert_rule_test:
+      - eval_time: 21m
+        alertname: RHACSTenantWorkloadMemoryUtilizationCritical
+        exp_alerts: []


### PR DESCRIPTION
We have seen that the tenant memory alerts are too noisy in their current state. See https://redhat-internal.slack.com/archives/C0313JYKH8W/p1702483155046459 for a discussion.

Tighten the alerts by:
* constrain to `central` containers.
* increase the thresholds.