### PR TITLE
chore: remove probe instances from table

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
@@ -35,7 +35,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 19,
+      "id": 27,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -972,19 +972,23 @@ data:
         },
         {
           "datasource": {
-            "uid": "-- Mixed --",
-            "type": "datasource"
+            "type": "datasource",
+            "uid": "-- Mixed --"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
               "custom": {
-                "align": "auto",
+                "align": "center",
                 "cellOptions": {
                   "type": "auto"
                 },
-                "inspect": false,
                 "filterable": true,
-                "minWidth": 200
+                "inspect": false,
+                "minWidth": 50
               },
               "mappings": [],
               "thresholds": {
@@ -999,9 +1003,6 @@ data:
                     "value": 80
                   }
                 ]
-              },
-              "color": {
-                "mode": "thresholds"
               }
             },
             "overrides": [
@@ -1048,7 +1049,7 @@ data:
                   },
                   {
                     "id": "custom.width",
-                    "value": 261
+                    "value": 184
                   }
                 ]
               },
@@ -1063,10 +1064,6 @@ data:
                     "value": {
                       "type": "color-text"
                     }
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 223
                   }
                 ]
               },
@@ -1079,10 +1076,6 @@ data:
                   {
                     "id": "unit",
                     "value": "binBps"
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 192
                   }
                 ]
               },
@@ -1095,10 +1088,6 @@ data:
                   {
                     "id": "unit",
                     "value": "binBps"
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 185
                   }
                 ]
               },
@@ -1110,7 +1099,7 @@ data:
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 109
+                    "value": 86
                   }
                 ]
               },
@@ -1122,43 +1111,7 @@ data:
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 82
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Organisation"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 223
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Secured Cores"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 160
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "namespace"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 264
+                    "value": 84
                   }
                 ]
               },
@@ -1195,6 +1148,18 @@ data:
                     "value": "right"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 242
+                  }
+                ]
               }
             ]
           },
@@ -1206,15 +1171,15 @@ data:
           },
           "id": 19,
           "options": {
-            "showHeader": true,
             "cellHeight": "sm",
             "footer": {
-              "show": false,
-              "reducer": ["sum"],
               "countRows": false,
+              "enablePagination": true,
               "fields": "",
-              "enablePagination": true
+              "reducer": ["sum"],
+              "show": false
             },
+            "showHeader": true,
             "sortBy": [
               {
                 "desc": true,
@@ -1245,43 +1210,13 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rox_central_cluster_metrics_cpu_capacity{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace)",
+              "expr": "sum(rox_central_secured_vcpus{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_org_id, rhacs_version, rhacs_expired_at)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
               "refId": "Secured Cores"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_version, rhacs_expired_at)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Metadata"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"central\"}[30m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "CPU throttle"
             },
             {
               "datasource": {
@@ -1335,13 +1270,14 @@ data:
               "id": "seriesToColumns",
               "options": {
                 "byField": "namespace",
-                "mode": "outer"
+                "mode": "inner"
               }
             },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
+                  "Time": true,
                   "Time 1": true,
                   "Time 2": true,
                   "Time 3": true,
@@ -1350,7 +1286,9 @@ data:
                   "Time 6": true,
                   "Time 7": true,
                   "Time 8": true,
+                  "Value #A": false,
                   "Value #Expired At": true,
+                  "Value #Metadata": true,
                   "Value #Organisation": true,
                   "Value #Version": true,
                   "__name__": true,
@@ -1361,32 +1299,31 @@ data:
                   "pod": true,
                   "rhacs_cluster_name": true,
                   "rhacs_environment": true,
-                  "Value #Metadata": true
+                  "rhacs_expired_at": false
                 },
                 "indexByName": {
-                  "namespace": 0,
+                  "Time": 10,
+                  "Time 2": 11,
+                  "Time 3": 12,
+                  "Time 4": 13,
+                  "Time 5": 14,
+                  "Value #A": 8,
                   "Value #Memory consumption": 1,
                   "Value #Network received": 2,
                   "Value #Network transmitted": 3,
                   "Value #Secured Cores": 4,
+                  "container": 15,
+                  "exported_instance": 16,
+                  "instance": 17,
+                  "job": 18,
+                  "namespace": 0,
+                  "pod": 19,
+                  "rhacs_cluster_name": 20,
+                  "rhacs_environment": 21,
+                  "rhacs_expired_at": 9,
+                  "rhacs_org_id": 6,
                   "rhacs_org_name": 5,
-                  "Time 1": 6,
-                  "Time 2": 7,
-                  "Time 3": 8,
-                  "Time 4": 9,
-                  "Time 5": 10,
-                  "Time 6": 11,
-                  "rhacs_version": 12,
-                  "Value #Metadata": 13,
-                  "container": 14,
-                  "exported_instance": 15,
-                  "instance": 16,
-                  "job": 17,
-                  "pod": 18,
-                  "rhacs_cluster_name": 19,
-                  "rhacs_environment": 20,
-                  "Value #A": 21,
-                  "rhacs_expired_at": 22
+                  "rhacs_version": 7
                 },
                 "renameByName": {
                   "Time 2": "",
@@ -1401,15 +1338,16 @@ data:
                   "Value #Organisation": "CPU seconds",
                   "Value #Secured Cores": "Secured Cores",
                   "Value #Version": "",
+                  "namespace": "Namespace",
                   "rhacs_expired_at": "Expired At",
-                  "rhacs_org_name": "Organisation",
+                  "rhacs_org_id": "Organization ID",
+                  "rhacs_org_name": "Organization",
                   "rhacs_version": "Version"
                 }
               }
             }
           ],
-          "type": "table",
-          "description": ""
+          "type": "table"
         },
         {
           "datasource": {
@@ -1422,10 +1360,11 @@ data:
                 "mode": "thresholds"
               },
               "custom": {
-                "align": "auto",
+                "align": "center",
                 "cellOptions": {
                   "type": "auto"
                 },
+                "filterable": true,
                 "inspect": false
               },
               "mappings": [],
@@ -1433,7 +1372,8 @@ data:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1470,7 +1410,8 @@ data:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1536,7 +1477,8 @@ data:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1582,7 +1524,8 @@ data:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1614,6 +1557,7 @@ data:
             "cellHeight": "sm",
             "footer": {
               "countRows": false,
+              "enablePagination": true,
               "fields": "",
               "reducer": ["sum"],
               "show": false
@@ -1679,43 +1623,13 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) /\nsum(container_spec_cpu_quota{namespace=~\"rhacs-$instance_id\", container=\"scanner\"} / container_spec_cpu_period{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}) by (namespace)",
+              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "CPU consumption"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) / sum(increase(container_cpu_cfs_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "CPU throttle"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Organisation"
+              "refId": "Organization"
             }
           ],
           "title": "Scanner Overview Table",
@@ -1723,7 +1637,8 @@ data:
             {
               "id": "seriesToColumns",
               "options": {
-                "byField": "namespace"
+                "byField": "namespace",
+                "mode": "inner"
               }
             },
             {
@@ -1738,23 +1653,21 @@ data:
                   "Time 5": true,
                   "Time 6": true,
                   "Value": false,
-                  "Value #Organisation": true
+                  "Value #Organisation": true,
+                  "Value #Organization": true
                 },
                 "indexByName": {
-                  "Time 1": 7,
-                  "Time 2": 8,
-                  "Time 3": 9,
-                  "Time 4": 10,
-                  "Time 5": 11,
-                  "Time 6": 12,
-                  "Value #CPU consumption": 2,
-                  "Value #CPU throttle": 3,
+                  "Time": 6,
+                  "Time 2": 7,
+                  "Time 3": 8,
+                  "Time 4": 9,
                   "Value #Memory consumption": 1,
-                  "Value #Network Transmitted": 5,
-                  "Value #Network received": 4,
-                  "Value #Organisation": 13,
+                  "Value #Network Transmitted": 3,
+                  "Value #Network received": 2,
+                  "Value #Organization": 10,
                   "namespace": 0,
-                  "rhacs_org_name": 6
+                  "rhacs_org_id": 5,
+                  "rhacs_org_name": 4
                 },
                 "renameByName": {
                   "Time": "",
@@ -1767,8 +1680,10 @@ data:
                   "Value #Network Transmitted": "Network transmitted",
                   "Value #Network received": "Network received",
                   "Value #Organisation": "",
-                  "namespace": "",
-                  "rhacs_org_name": "Organisation"
+                  "Value #Organization": "",
+                  "namespace": "Namespace",
+                  "rhacs_org_id": "Organization ID",
+                  "rhacs_org_name": "Organization"
                 }
               }
             }
@@ -1779,7 +1694,7 @@ data:
       "refresh": "",
       "revision": 1,
       "schemaVersion": 38,
-      "tags": ["rhacs"],
+      "tags": [],
       "templating": {
         "list": [
           {
@@ -1904,6 +1819,6 @@ data:
       "timezone": "",
       "title": "RHACS Dataplane - Cluster Metrics",
       "uid": "4032f3c17643119901e107a0a1786d5b9e4c9565",
-      "version": 5,
+      "version": 1,
       "weekStart": ""
     }

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
@@ -35,7 +35,7 @@ spec:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 19,
+      "id": 27,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -972,19 +972,23 @@ spec:
         },
         {
           "datasource": {
-            "uid": "-- Mixed --",
-            "type": "datasource"
+            "type": "datasource",
+            "uid": "-- Mixed --"
           },
+          "description": "",
           "fieldConfig": {
             "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
               "custom": {
-                "align": "auto",
+                "align": "center",
                 "cellOptions": {
                   "type": "auto"
                 },
-                "inspect": false,
                 "filterable": true,
-                "minWidth": 200
+                "inspect": false,
+                "minWidth": 50
               },
               "mappings": [],
               "thresholds": {
@@ -999,9 +1003,6 @@ spec:
                     "value": 80
                   }
                 ]
-              },
-              "color": {
-                "mode": "thresholds"
               }
             },
             "overrides": [
@@ -1048,7 +1049,7 @@ spec:
                   },
                   {
                     "id": "custom.width",
-                    "value": 261
+                    "value": 184
                   }
                 ]
               },
@@ -1063,10 +1064,6 @@ spec:
                     "value": {
                       "type": "color-text"
                     }
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 223
                   }
                 ]
               },
@@ -1079,10 +1076,6 @@ spec:
                   {
                     "id": "unit",
                     "value": "binBps"
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 192
                   }
                 ]
               },
@@ -1095,10 +1088,6 @@ spec:
                   {
                     "id": "unit",
                     "value": "binBps"
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 185
                   }
                 ]
               },
@@ -1110,7 +1099,7 @@ spec:
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 109
+                    "value": 86
                   }
                 ]
               },
@@ -1122,43 +1111,7 @@ spec:
                 "properties": [
                   {
                     "id": "custom.width",
-                    "value": 82
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Organisation"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 223
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Secured Cores"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 160
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "namespace"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 264
+                    "value": 84
                   }
                 ]
               },
@@ -1195,6 +1148,18 @@ spec:
                     "value": "right"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 242
+                  }
+                ]
               }
             ]
           },
@@ -1206,15 +1171,15 @@ spec:
           },
           "id": 19,
           "options": {
-            "showHeader": true,
             "cellHeight": "sm",
             "footer": {
-              "show": false,
-              "reducer": ["sum"],
               "countRows": false,
+              "enablePagination": true,
               "fields": "",
-              "enablePagination": true
+              "reducer": ["sum"],
+              "show": false
             },
+            "showHeader": true,
             "sortBy": [
               {
                 "desc": true,
@@ -1245,43 +1210,13 @@ spec:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rox_central_cluster_metrics_cpu_capacity{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace)",
+              "expr": "sum(rox_central_secured_vcpus{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_org_id, rhacs_version, rhacs_expired_at)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
               "refId": "Secured Cores"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_version, rhacs_expired_at)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Metadata"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"central\"}[30m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "CPU throttle"
             },
             {
               "datasource": {
@@ -1335,13 +1270,14 @@ spec:
               "id": "seriesToColumns",
               "options": {
                 "byField": "namespace",
-                "mode": "outer"
+                "mode": "inner"
               }
             },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
+                  "Time": true,
                   "Time 1": true,
                   "Time 2": true,
                   "Time 3": true,
@@ -1350,7 +1286,9 @@ spec:
                   "Time 6": true,
                   "Time 7": true,
                   "Time 8": true,
+                  "Value #A": false,
                   "Value #Expired At": true,
+                  "Value #Metadata": true,
                   "Value #Organisation": true,
                   "Value #Version": true,
                   "__name__": true,
@@ -1361,32 +1299,31 @@ spec:
                   "pod": true,
                   "rhacs_cluster_name": true,
                   "rhacs_environment": true,
-                  "Value #Metadata": true
+                  "rhacs_expired_at": false
                 },
                 "indexByName": {
-                  "namespace": 0,
+                  "Time": 10,
+                  "Time 2": 11,
+                  "Time 3": 12,
+                  "Time 4": 13,
+                  "Time 5": 14,
+                  "Value #A": 8,
                   "Value #Memory consumption": 1,
                   "Value #Network received": 2,
                   "Value #Network transmitted": 3,
                   "Value #Secured Cores": 4,
+                  "container": 15,
+                  "exported_instance": 16,
+                  "instance": 17,
+                  "job": 18,
+                  "namespace": 0,
+                  "pod": 19,
+                  "rhacs_cluster_name": 20,
+                  "rhacs_environment": 21,
+                  "rhacs_expired_at": 9,
+                  "rhacs_org_id": 6,
                   "rhacs_org_name": 5,
-                  "Time 1": 6,
-                  "Time 2": 7,
-                  "Time 3": 8,
-                  "Time 4": 9,
-                  "Time 5": 10,
-                  "Time 6": 11,
-                  "rhacs_version": 12,
-                  "Value #Metadata": 13,
-                  "container": 14,
-                  "exported_instance": 15,
-                  "instance": 16,
-                  "job": 17,
-                  "pod": 18,
-                  "rhacs_cluster_name": 19,
-                  "rhacs_environment": 20,
-                  "Value #A": 21,
-                  "rhacs_expired_at": 22
+                  "rhacs_version": 7
                 },
                 "renameByName": {
                   "Time 2": "",
@@ -1401,15 +1338,16 @@ spec:
                   "Value #Organisation": "CPU seconds",
                   "Value #Secured Cores": "Secured Cores",
                   "Value #Version": "",
+                  "namespace": "Namespace",
                   "rhacs_expired_at": "Expired At",
-                  "rhacs_org_name": "Organisation",
+                  "rhacs_org_id": "Organization ID",
+                  "rhacs_org_name": "Organization",
                   "rhacs_version": "Version"
                 }
               }
             }
           ],
-          "type": "table",
-          "description": ""
+          "type": "table"
         },
         {
           "datasource": {
@@ -1422,10 +1360,11 @@ spec:
                 "mode": "thresholds"
               },
               "custom": {
-                "align": "auto",
+                "align": "center",
                 "cellOptions": {
                   "type": "auto"
                 },
+                "filterable": true,
                 "inspect": false
               },
               "mappings": [],
@@ -1433,7 +1372,8 @@ spec:
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1470,7 +1410,8 @@ spec:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1536,7 +1477,8 @@ spec:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1582,7 +1524,8 @@ spec:
                       "mode": "percentage",
                       "steps": [
                         {
-                          "color": "green"
+                          "color": "green",
+                          "value": null
                         },
                         {
                           "color": "orange",
@@ -1614,6 +1557,7 @@ spec:
             "cellHeight": "sm",
             "footer": {
               "countRows": false,
+              "enablePagination": true,
               "fields": "",
               "reducer": ["sum"],
               "show": false
@@ -1679,43 +1623,13 @@ spec:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) /\nsum(container_spec_cpu_quota{namespace=~\"rhacs-$instance_id\", container=\"scanner\"} / container_spec_cpu_period{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}) by (namespace)",
+              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "CPU consumption"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) / sum(increase(container_cpu_cfs_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "CPU throttle"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Organisation"
+              "refId": "Organization"
             }
           ],
           "title": "Scanner Overview Table",
@@ -1723,7 +1637,8 @@ spec:
             {
               "id": "seriesToColumns",
               "options": {
-                "byField": "namespace"
+                "byField": "namespace",
+                "mode": "inner"
               }
             },
             {
@@ -1738,23 +1653,21 @@ spec:
                   "Time 5": true,
                   "Time 6": true,
                   "Value": false,
-                  "Value #Organisation": true
+                  "Value #Organisation": true,
+                  "Value #Organization": true
                 },
                 "indexByName": {
-                  "Time 1": 7,
-                  "Time 2": 8,
-                  "Time 3": 9,
-                  "Time 4": 10,
-                  "Time 5": 11,
-                  "Time 6": 12,
-                  "Value #CPU consumption": 2,
-                  "Value #CPU throttle": 3,
+                  "Time": 6,
+                  "Time 2": 7,
+                  "Time 3": 8,
+                  "Time 4": 9,
                   "Value #Memory consumption": 1,
-                  "Value #Network Transmitted": 5,
-                  "Value #Network received": 4,
-                  "Value #Organisation": 13,
+                  "Value #Network Transmitted": 3,
+                  "Value #Network received": 2,
+                  "Value #Organization": 10,
                   "namespace": 0,
-                  "rhacs_org_name": 6
+                  "rhacs_org_id": 5,
+                  "rhacs_org_name": 4
                 },
                 "renameByName": {
                   "Time": "",
@@ -1767,8 +1680,10 @@ spec:
                   "Value #Network Transmitted": "Network transmitted",
                   "Value #Network received": "Network received",
                   "Value #Organisation": "",
-                  "namespace": "",
-                  "rhacs_org_name": "Organisation"
+                  "Value #Organization": "",
+                  "namespace": "Namespace",
+                  "rhacs_org_id": "Organization ID",
+                  "rhacs_org_name": "Organization"
                 }
               }
             }
@@ -1779,7 +1694,7 @@ spec:
       "refresh": "",
       "revision": 1,
       "schemaVersion": 38,
-      "tags": ["rhacs"],
+      "tags": [],
       "templating": {
         "list": [
           {
@@ -1904,6 +1819,6 @@ spec:
       "timezone": "",
       "title": "RHACS Dataplane - Cluster Metrics",
       "uid": "4032f3c17643119901e107a0a1786d5b9e4c9565",
-      "version": 5,
+      "version": 1,
       "weekStart": ""
     }

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 19,
+  "id": 27,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -961,19 +961,23 @@
     },
     {
       "datasource": {
-        "uid": "-- Mixed --",
-        "type": "datasource"
+        "type": "datasource",
+        "uid": "-- Mixed --"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
-            "align": "auto",
+            "align": "center",
             "cellOptions": {
               "type": "auto"
             },
-            "inspect": false,
             "filterable": true,
-            "minWidth": 200
+            "inspect": false,
+            "minWidth": 50
           },
           "mappings": [],
           "thresholds": {
@@ -988,9 +992,6 @@
                 "value": 80
               }
             ]
-          },
-          "color": {
-            "mode": "thresholds"
           }
         },
         "overrides": [
@@ -1037,7 +1038,7 @@
               },
               {
                 "id": "custom.width",
-                "value": 261
+                "value": 184
               }
             ]
           },
@@ -1052,10 +1053,6 @@
                 "value": {
                   "type": "color-text"
                 }
-              },
-              {
-                "id": "custom.width",
-                "value": 223
               }
             ]
           },
@@ -1068,10 +1065,6 @@
               {
                 "id": "unit",
                 "value": "binBps"
-              },
-              {
-                "id": "custom.width",
-                "value": 192
               }
             ]
           },
@@ -1084,10 +1077,6 @@
               {
                 "id": "unit",
                 "value": "binBps"
-              },
-              {
-                "id": "custom.width",
-                "value": 185
               }
             ]
           },
@@ -1099,7 +1088,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 109
+                "value": 86
               }
             ]
           },
@@ -1111,43 +1100,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 82
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Organisation"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 223
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Secured Cores"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 160
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "namespace"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 264
+                "value": 84
               }
             ]
           },
@@ -1184,6 +1137,18 @@
                 "value": "right"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 242
+              }
+            ]
           }
         ]
       },
@@ -1195,15 +1160,15 @@
       },
       "id": 19,
       "options": {
-        "showHeader": true,
         "cellHeight": "sm",
         "footer": {
-          "show": false,
-          "reducer": ["sum"],
           "countRows": false,
+          "enablePagination": true,
           "fields": "",
-          "enablePagination": true
+          "reducer": ["sum"],
+          "show": false
         },
+        "showHeader": true,
         "sortBy": [
           {
             "desc": true,
@@ -1234,43 +1199,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rox_central_cluster_metrics_cpu_capacity{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace)",
+          "expr": "sum(rox_central_secured_vcpus{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_org_id, rhacs_version, rhacs_expired_at)",
           "format": "table",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
           "refId": "Secured Cores"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"central\"}) by (namespace, rhacs_org_name, rhacs_version, rhacs_expired_at)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Metadata"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"central\"}[30m])) by (namespace)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CPU throttle"
         },
         {
           "datasource": {
@@ -1324,13 +1259,14 @@
           "id": "seriesToColumns",
           "options": {
             "byField": "namespace",
-            "mode": "outer"
+            "mode": "inner"
           }
         },
         {
           "id": "organize",
           "options": {
             "excludeByName": {
+              "Time": true,
               "Time 1": true,
               "Time 2": true,
               "Time 3": true,
@@ -1339,7 +1275,9 @@
               "Time 6": true,
               "Time 7": true,
               "Time 8": true,
+              "Value #A": false,
               "Value #Expired At": true,
+              "Value #Metadata": true,
               "Value #Organisation": true,
               "Value #Version": true,
               "__name__": true,
@@ -1350,32 +1288,31 @@
               "pod": true,
               "rhacs_cluster_name": true,
               "rhacs_environment": true,
-              "Value #Metadata": true
+              "rhacs_expired_at": false
             },
             "indexByName": {
-              "namespace": 0,
+              "Time": 10,
+              "Time 2": 11,
+              "Time 3": 12,
+              "Time 4": 13,
+              "Time 5": 14,
+              "Value #A": 8,
               "Value #Memory consumption": 1,
               "Value #Network received": 2,
               "Value #Network transmitted": 3,
               "Value #Secured Cores": 4,
+              "container": 15,
+              "exported_instance": 16,
+              "instance": 17,
+              "job": 18,
+              "namespace": 0,
+              "pod": 19,
+              "rhacs_cluster_name": 20,
+              "rhacs_environment": 21,
+              "rhacs_expired_at": 9,
+              "rhacs_org_id": 6,
               "rhacs_org_name": 5,
-              "Time 1": 6,
-              "Time 2": 7,
-              "Time 3": 8,
-              "Time 4": 9,
-              "Time 5": 10,
-              "Time 6": 11,
-              "rhacs_version": 12,
-              "Value #Metadata": 13,
-              "container": 14,
-              "exported_instance": 15,
-              "instance": 16,
-              "job": 17,
-              "pod": 18,
-              "rhacs_cluster_name": 19,
-              "rhacs_environment": 20,
-              "Value #A": 21,
-              "rhacs_expired_at": 22
+              "rhacs_version": 7
             },
             "renameByName": {
               "Time 2": "",
@@ -1390,15 +1327,16 @@
               "Value #Organisation": "CPU seconds",
               "Value #Secured Cores": "Secured Cores",
               "Value #Version": "",
+              "namespace": "Namespace",
               "rhacs_expired_at": "Expired At",
-              "rhacs_org_name": "Organisation",
+              "rhacs_org_id": "Organization ID",
+              "rhacs_org_name": "Organization",
               "rhacs_version": "Version"
             }
           }
         }
       ],
-      "type": "table",
-      "description": ""
+      "type": "table"
     },
     {
       "datasource": {
@@ -1411,10 +1349,11 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "center",
             "cellOptions": {
               "type": "auto"
             },
+            "filterable": true,
             "inspect": false
           },
           "mappings": [],
@@ -1422,7 +1361,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1459,7 +1399,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "green"
+                      "color": "green",
+                      "value": null
                     },
                     {
                       "color": "orange",
@@ -1525,7 +1466,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "green"
+                      "color": "green",
+                      "value": null
                     },
                     {
                       "color": "orange",
@@ -1571,7 +1513,8 @@
                   "mode": "percentage",
                   "steps": [
                     {
-                      "color": "green"
+                      "color": "green",
+                      "value": null
                     },
                     {
                       "color": "orange",
@@ -1603,6 +1546,7 @@
         "cellHeight": "sm",
         "footer": {
           "countRows": false,
+          "enablePagination": true,
           "fields": "",
           "reducer": ["sum"],
           "show": false
@@ -1668,43 +1612,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) /\nsum(container_spec_cpu_quota{namespace=~\"rhacs-$instance_id\", container=\"scanner\"} / container_spec_cpu_period{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}) by (namespace)",
+          "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
           "format": "table",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "CPU consumption"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace) / sum(increase(container_cpu_cfs_periods_total{namespace=~\"rhacs-$instance_id\", container=\"scanner\"}[5m])) by (namespace)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CPU throttle"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Organisation"
+          "refId": "Organization"
         }
       ],
       "title": "Scanner Overview Table",
@@ -1712,7 +1626,8 @@
         {
           "id": "seriesToColumns",
           "options": {
-            "byField": "namespace"
+            "byField": "namespace",
+            "mode": "inner"
           }
         },
         {
@@ -1727,23 +1642,21 @@
               "Time 5": true,
               "Time 6": true,
               "Value": false,
-              "Value #Organisation": true
+              "Value #Organisation": true,
+              "Value #Organization": true
             },
             "indexByName": {
-              "Time 1": 7,
-              "Time 2": 8,
-              "Time 3": 9,
-              "Time 4": 10,
-              "Time 5": 11,
-              "Time 6": 12,
-              "Value #CPU consumption": 2,
-              "Value #CPU throttle": 3,
+              "Time": 6,
+              "Time 2": 7,
+              "Time 3": 8,
+              "Time 4": 9,
               "Value #Memory consumption": 1,
-              "Value #Network Transmitted": 5,
-              "Value #Network received": 4,
-              "Value #Organisation": 13,
+              "Value #Network Transmitted": 3,
+              "Value #Network received": 2,
+              "Value #Organization": 10,
               "namespace": 0,
-              "rhacs_org_name": 6
+              "rhacs_org_id": 5,
+              "rhacs_org_name": 4
             },
             "renameByName": {
               "Time": "",
@@ -1756,8 +1669,10 @@
               "Value #Network Transmitted": "Network transmitted",
               "Value #Network received": "Network received",
               "Value #Organisation": "",
-              "namespace": "",
-              "rhacs_org_name": "Organisation"
+              "Value #Organization": "",
+              "namespace": "Namespace",
+              "rhacs_org_id": "Organization ID",
+              "rhacs_org_name": "Organization"
             }
           }
         }
@@ -1768,7 +1683,7 @@
   "refresh": "",
   "revision": 1,
   "schemaVersion": 38,
-  "tags": ["rhacs"],
+  "tags": [],
   "templating": {
     "list": [
       {
@@ -1893,6 +1808,6 @@
   "timezone": "",
   "title": "RHACS Dataplane - Cluster Metrics",
   "uid": "4032f3c17643119901e107a0a1786d5b9e4c9565",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
More improvements to the cluster overview dashboard:

* use `inner` instead of `outer` joins in the central/scanner tables. This removes the spurious probe instances.
* add `Organization ID` columns.
* some minor cosmetic adjustments of the columns widths to try to fit one more column.

Link to test dashboard: https://grafana-route-rhacs-observability.apps.acs-prod-dp-01.pnz3.p1.openshiftapps.com/d/cb108eaa-ab11-4016-b1c0-46e063f41b1d/stehessel-rhacs-dataplane-cluster-metrics?orgId=1 

Screenshot:
<img width="1511" alt="Screenshot 2024-02-15 at 23 06 41" src="https://github.com/stackrox/rhacs-observability-resources/assets/55607356/aaaeadbf-ea99-45dc-b04b-a3a1b7e4af0f">

