### PR TITLE
chore: add auto-merge in sync

### DIFF
--- a/.github/workflows/sync-prod-from-stage.yaml
+++ b/.github/workflows/sync-prod-from-stage.yaml
@@ -10,8 +10,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Opening pull request
         id: pull
-        uses: tretuna/sync-branches@1.4.0
+        # We need main for PULL_REQUEST_AUTO_MERGE_METHOD, which is currently not yet released.
+        uses: tretuna/sync-branches@main
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "stage"
           TO_BRANCH: "production"
+          PULL_REQUEST_AUTO_MERGE_METHOD: merge

--- a/.github/workflows/sync-stage-from-master.yaml
+++ b/.github/workflows/sync-stage-from-master.yaml
@@ -10,8 +10,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Opening pull request
         id: pull
-        uses: tretuna/sync-branches@1.4.0
+        # We need main for PULL_REQUEST_AUTO_MERGE_METHOD, which is currently not yet released.
+        uses: tretuna/sync-branches@main
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
           TO_BRANCH: "stage"
+          PULL_REQUEST_AUTO_MERGE_METHOD: merge


### PR DESCRIPTION
Prevent merge conflicts due to squash commits when syncing `master` -> `stage` -> `production`.