### PR TITLE
ROX-22677: Add ScannerV4 components to Scanner Overview table

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
@@ -1386,7 +1386,39 @@ data:
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Value #Memory consumption"
+                  "options": "ScannerV2 memory"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ScannerV2 CPU"
                 },
                 "properties": [
                   {
@@ -1401,10 +1433,6 @@ data:
                     }
                   },
                   {
-                    "id": "max",
-                    "value": 1
-                  },
-                  {
                     "id": "thresholds",
                     "value": {
                       "mode": "percentage",
@@ -1414,8 +1442,8 @@ data:
                           "value": null
                         },
                         {
-                          "color": "orange",
-                          "value": 70
+                          "color": "#EAB839",
+                          "value": 60
                         },
                         {
                           "color": "red",
@@ -1423,46 +1451,54 @@ data:
                         }
                       ]
                     }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Network received"
+                  "options": "Matcher memory"
                 },
                 "properties": [
                   {
                     "id": "unit",
-                    "value": "Bps"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Network transmitted"
-                },
-                "properties": [
+                    "value": "decbytes"
+                  },
                   {
-                    "id": "unit",
-                    "value": "Bps"
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "CPU consumption"
+                  "options": "Matcher CPU"
                 },
                 "properties": [
                   {
                     "id": "unit",
                     "value": "percentunit"
-                  },
-                  {
-                    "id": "max",
-                    "value": 1
                   },
                   {
                     "id": "custom.cellOptions",
@@ -1481,35 +1517,63 @@ data:
                           "value": null
                         },
                         {
-                          "color": "orange",
+                          "color": "yellow",
                           "value": 60
                         },
                         {
                           "color": "red",
-                          "value": 80
+                          "value": 90
                         }
                       ]
                     }
                   },
                   {
                     "id": "decimals",
-                    "value": 2
+                    "value": 1
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "CPU throttle"
+                  "options": "Indexer memory"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Indexer CPU"
                 },
                 "properties": [
                   {
                     "id": "unit",
                     "value": "percentunit"
-                  },
-                  {
-                    "id": "max",
-                    "value": 1
                   },
                   {
                     "id": "custom.cellOptions",
@@ -1528,12 +1592,12 @@ data:
                           "value": null
                         },
                         {
-                          "color": "orange",
-                          "value": 10
+                          "color": "#EAB839",
+                          "value": 60
                         },
                         {
                           "color": "red",
-                          "value": 50
+                          "value": 90
                         }
                       ]
                     }
@@ -1541,6 +1605,30 @@ data:
                   {
                     "id": "decimals",
                     "value": 1
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Organization"
+                },
+                "properties": [
+                  {
+                    "id": "noValue",
+                    "value": "DELETED"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Version"
+                },
+                "properties": [
+                  {
+                    "id": "noValue",
+                    "value": "DELETED"
                   }
                 ]
               }
@@ -1579,12 +1667,12 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace) / sum(container_spec_memory_limit_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}) by (namespace)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "Memory consumption"
+              "refId": "ScannerV2 memory"
             },
             {
               "datasource": {
@@ -1593,28 +1681,13 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Network received"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}[$__range])) by (namespace)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "Network Transmitted"
+              "refId": "ScannerV2 CPU"
             },
             {
               "datasource": {
@@ -1623,13 +1696,73 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Matcher memory"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}[$__range])) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Matcher CPU"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_version)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
               "refId": "Organization"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Indexer memory"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}[$__range])) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Indexer CPU"
             }
           ],
           "title": "Scanner Overview Table",
@@ -1638,7 +1771,7 @@ data:
               "id": "seriesToColumns",
               "options": {
                 "byField": "namespace",
-                "mode": "inner"
+                "mode": "outer"
               }
             },
             {
@@ -1657,33 +1790,47 @@ data:
                   "Value #Organization": true
                 },
                 "indexByName": {
-                  "Time": 6,
-                  "Time 2": 7,
-                  "Time 3": 8,
-                  "Time 4": 9,
-                  "Value #Memory consumption": 1,
-                  "Value #Network Transmitted": 3,
-                  "Value #Network received": 2,
-                  "Value #Organization": 10,
+                  "Time 1": 13,
+                  "Time 2": 9,
+                  "Time 3": 10,
+                  "Time 4": 11,
+                  "Time 5": 14,
+                  "Time 6": 15,
+                  "Time 7": 16,
+                  "Value #Indexer CPU": 6,
+                  "Value #Indexer memory": 5,
+                  "Value #Matcher CPU": 4,
+                  "Value #Matcher memory": 3,
+                  "Value #Organization": 12,
+                  "Value #ScannerV2 CPU": 2,
+                  "Value #ScannerV2 memory": 1,
                   "namespace": 0,
-                  "rhacs_org_id": 5,
-                  "rhacs_org_name": 4
+                  "rhacs_org_name": 7,
+                  "rhacs_version": 8
                 },
                 "renameByName": {
                   "Time": "",
+                  "Time 7": "",
                   "Value": "CPU consumption",
                   "Value #A": "",
                   "Value #CPU Throttle": "CPU throttle",
                   "Value #CPU consumption": "CPU consumption",
                   "Value #CPU throttle": "CPU throttle",
+                  "Value #Indexer CPU": "Indexer CPU",
+                  "Value #Indexer memory": "Indexer memory",
+                  "Value #Matcher CPU": "Matcher CPU",
+                  "Value #Matcher memory": "Matcher memory",
                   "Value #Memory consumption": "Memory consumption",
                   "Value #Network Transmitted": "Network transmitted",
                   "Value #Network received": "Network received",
                   "Value #Organisation": "",
                   "Value #Organization": "",
+                  "Value #ScannerV2 CPU": "ScannerV2 CPU",
+                  "Value #ScannerV2 memory": "ScannerV2 memory",
                   "namespace": "Namespace",
                   "rhacs_org_id": "Organization ID",
-                  "rhacs_org_name": "Organization"
+                  "rhacs_org_name": "Organization",
+                  "rhacs_version": "Version"
                 }
               }
             }

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
@@ -1386,7 +1386,39 @@ spec:
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Value #Memory consumption"
+                  "options": "ScannerV2 memory"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ScannerV2 CPU"
                 },
                 "properties": [
                   {
@@ -1401,10 +1433,6 @@ spec:
                     }
                   },
                   {
-                    "id": "max",
-                    "value": 1
-                  },
-                  {
                     "id": "thresholds",
                     "value": {
                       "mode": "percentage",
@@ -1414,8 +1442,8 @@ spec:
                           "value": null
                         },
                         {
-                          "color": "orange",
-                          "value": 70
+                          "color": "#EAB839",
+                          "value": 60
                         },
                         {
                           "color": "red",
@@ -1423,46 +1451,54 @@ spec:
                         }
                       ]
                     }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Network received"
+                  "options": "Matcher memory"
                 },
                 "properties": [
                   {
                     "id": "unit",
-                    "value": "Bps"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Network transmitted"
-                },
-                "properties": [
+                    "value": "decbytes"
+                  },
                   {
-                    "id": "unit",
-                    "value": "Bps"
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "CPU consumption"
+                  "options": "Matcher CPU"
                 },
                 "properties": [
                   {
                     "id": "unit",
                     "value": "percentunit"
-                  },
-                  {
-                    "id": "max",
-                    "value": 1
                   },
                   {
                     "id": "custom.cellOptions",
@@ -1481,35 +1517,63 @@ spec:
                           "value": null
                         },
                         {
-                          "color": "orange",
+                          "color": "yellow",
                           "value": 60
                         },
                         {
                           "color": "red",
-                          "value": 80
+                          "value": 90
                         }
                       ]
                     }
                   },
                   {
                     "id": "decimals",
-                    "value": 2
+                    "value": 1
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "CPU throttle"
+                  "options": "Indexer memory"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-GrYlRd"
+                    }
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 0
+                  },
+                  {
+                    "id": "noValue",
+                    "value": "-"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Indexer CPU"
                 },
                 "properties": [
                   {
                     "id": "unit",
                     "value": "percentunit"
-                  },
-                  {
-                    "id": "max",
-                    "value": 1
                   },
                   {
                     "id": "custom.cellOptions",
@@ -1528,12 +1592,12 @@ spec:
                           "value": null
                         },
                         {
-                          "color": "orange",
-                          "value": 10
+                          "color": "#EAB839",
+                          "value": 60
                         },
                         {
                           "color": "red",
-                          "value": 50
+                          "value": 90
                         }
                       ]
                     }
@@ -1541,6 +1605,30 @@ spec:
                   {
                     "id": "decimals",
                     "value": 1
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Organization"
+                },
+                "properties": [
+                  {
+                    "id": "noValue",
+                    "value": "DELETED"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Version"
+                },
+                "properties": [
+                  {
+                    "id": "noValue",
+                    "value": "DELETED"
                   }
                 ]
               }
@@ -1579,12 +1667,12 @@ spec:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace) / sum(container_spec_memory_limit_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}) by (namespace)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "Memory consumption"
+              "refId": "ScannerV2 memory"
             },
             {
               "datasource": {
@@ -1593,28 +1681,13 @@ spec:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
-              "format": "table",
-              "hide": false,
-              "instant": true,
-              "legendFormat": "__auto",
-              "range": false,
-              "refId": "Network received"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
-              },
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}[$__range])) by (namespace)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
-              "refId": "Network Transmitted"
+              "refId": "ScannerV2 CPU"
             },
             {
               "datasource": {
@@ -1623,13 +1696,73 @@ spec:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Matcher memory"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}[$__range])) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Matcher CPU"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_version)",
               "format": "table",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
               "refId": "Organization"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Indexer memory"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}[$__range])) by (namespace)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "__auto",
+              "range": false,
+              "refId": "Indexer CPU"
             }
           ],
           "title": "Scanner Overview Table",
@@ -1638,7 +1771,7 @@ spec:
               "id": "seriesToColumns",
               "options": {
                 "byField": "namespace",
-                "mode": "inner"
+                "mode": "outer"
               }
             },
             {
@@ -1657,33 +1790,47 @@ spec:
                   "Value #Organization": true
                 },
                 "indexByName": {
-                  "Time": 6,
-                  "Time 2": 7,
-                  "Time 3": 8,
-                  "Time 4": 9,
-                  "Value #Memory consumption": 1,
-                  "Value #Network Transmitted": 3,
-                  "Value #Network received": 2,
-                  "Value #Organization": 10,
+                  "Time 1": 13,
+                  "Time 2": 9,
+                  "Time 3": 10,
+                  "Time 4": 11,
+                  "Time 5": 14,
+                  "Time 6": 15,
+                  "Time 7": 16,
+                  "Value #Indexer CPU": 6,
+                  "Value #Indexer memory": 5,
+                  "Value #Matcher CPU": 4,
+                  "Value #Matcher memory": 3,
+                  "Value #Organization": 12,
+                  "Value #ScannerV2 CPU": 2,
+                  "Value #ScannerV2 memory": 1,
                   "namespace": 0,
-                  "rhacs_org_id": 5,
-                  "rhacs_org_name": 4
+                  "rhacs_org_name": 7,
+                  "rhacs_version": 8
                 },
                 "renameByName": {
                   "Time": "",
+                  "Time 7": "",
                   "Value": "CPU consumption",
                   "Value #A": "",
                   "Value #CPU Throttle": "CPU throttle",
                   "Value #CPU consumption": "CPU consumption",
                   "Value #CPU throttle": "CPU throttle",
+                  "Value #Indexer CPU": "Indexer CPU",
+                  "Value #Indexer memory": "Indexer memory",
+                  "Value #Matcher CPU": "Matcher CPU",
+                  "Value #Matcher memory": "Matcher memory",
                   "Value #Memory consumption": "Memory consumption",
                   "Value #Network Transmitted": "Network transmitted",
                   "Value #Network received": "Network received",
                   "Value #Organisation": "",
                   "Value #Organization": "",
+                  "Value #ScannerV2 CPU": "ScannerV2 CPU",
+                  "Value #ScannerV2 memory": "ScannerV2 memory",
                   "namespace": "Namespace",
                   "rhacs_org_id": "Organization ID",
-                  "rhacs_org_name": "Organization"
+                  "rhacs_org_name": "Organization",
+                  "rhacs_version": "Version"
                 }
               }
             }

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -1375,7 +1375,39 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Value #Memory consumption"
+              "options": "ScannerV2 memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "noValue",
+                "value": "-"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ScannerV2 CPU"
             },
             "properties": [
               {
@@ -1390,10 +1422,6 @@
                 }
               },
               {
-                "id": "max",
-                "value": 1
-              },
-              {
                 "id": "thresholds",
                 "value": {
                   "mode": "percentage",
@@ -1403,8 +1431,8 @@
                       "value": null
                     },
                     {
-                      "color": "orange",
-                      "value": 70
+                      "color": "#EAB839",
+                      "value": 60
                     },
                     {
                       "color": "red",
@@ -1412,46 +1440,54 @@
                     }
                   ]
                 }
+              },
+              {
+                "id": "decimals",
+                "value": 1
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "Network received"
+              "options": "Matcher memory"
             },
             "properties": [
               {
                 "id": "unit",
-                "value": "Bps"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Network transmitted"
-            },
-            "properties": [
+                "value": "decbytes"
+              },
               {
-                "id": "unit",
-                "value": "Bps"
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "noValue",
+                "value": "-"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "CPU consumption"
+              "options": "Matcher CPU"
             },
             "properties": [
               {
                 "id": "unit",
                 "value": "percentunit"
-              },
-              {
-                "id": "max",
-                "value": 1
               },
               {
                 "id": "custom.cellOptions",
@@ -1470,35 +1506,63 @@
                       "value": null
                     },
                     {
-                      "color": "orange",
+                      "color": "yellow",
                       "value": 60
                     },
                     {
                       "color": "red",
-                      "value": 80
+                      "value": 90
                     }
                   ]
                 }
               },
               {
                 "id": "decimals",
-                "value": 2
+                "value": 1
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "CPU throttle"
+              "options": "Indexer memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-GrYlRd"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "noValue",
+                "value": "-"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Indexer CPU"
             },
             "properties": [
               {
                 "id": "unit",
                 "value": "percentunit"
-              },
-              {
-                "id": "max",
-                "value": 1
               },
               {
                 "id": "custom.cellOptions",
@@ -1517,12 +1581,12 @@
                       "value": null
                     },
                     {
-                      "color": "orange",
-                      "value": 10
+                      "color": "#EAB839",
+                      "value": 60
                     },
                     {
                       "color": "red",
-                      "value": 50
+                      "value": 90
                     }
                   ]
                 }
@@ -1530,6 +1594,30 @@
               {
                 "id": "decimals",
                 "value": 1
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Organization"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "DELETED"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Version"
+            },
+            "properties": [
+              {
+                "id": "noValue",
+                "value": "DELETED"
               }
             ]
           }
@@ -1568,12 +1656,12 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace) / sum(container_spec_memory_limit_bytes{namespace=~\"rhacs-$instance_id\", container=\"scanner\", job=~\"kubelet\"}) by (namespace)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}) by (namespace)",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "Memory consumption"
+          "refId": "ScannerV2 memory"
         },
         {
           "datasource": {
@@ -1582,28 +1670,13 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Network received"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"rhacs-$instance_id\", job=~\"kubelet\", pod=~\"scanner-.*\"}[5m])) by (namespace)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"scanner\"}[$__range])) by (namespace)",
           "format": "table",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "Network Transmitted"
+          "refId": "ScannerV2 CPU"
         },
         {
           "datasource": {
@@ -1612,13 +1685,73 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_org_id)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}) by (namespace)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Matcher memory"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"matcher\"}[$__range])) by (namespace)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Matcher CPU"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(process_cpu_seconds_total{namespace=~\"rhacs-$instance_id\", job=~\"scanner\"}) by (namespace, rhacs_org_name, rhacs_version)",
           "format": "table",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
           "refId": "Organization"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(container_memory_working_set_bytes{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}) by (namespace)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Indexer memory"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"rhacs-$instance_id\", job=\"kubelet\", container=\"indexer\"}[$__range])) by (namespace)",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "Indexer CPU"
         }
       ],
       "title": "Scanner Overview Table",
@@ -1627,7 +1760,7 @@
           "id": "seriesToColumns",
           "options": {
             "byField": "namespace",
-            "mode": "inner"
+            "mode": "outer"
           }
         },
         {
@@ -1646,33 +1779,47 @@
               "Value #Organization": true
             },
             "indexByName": {
-              "Time": 6,
-              "Time 2": 7,
-              "Time 3": 8,
-              "Time 4": 9,
-              "Value #Memory consumption": 1,
-              "Value #Network Transmitted": 3,
-              "Value #Network received": 2,
-              "Value #Organization": 10,
+              "Time 1": 13,
+              "Time 2": 9,
+              "Time 3": 10,
+              "Time 4": 11,
+              "Time 5": 14,
+              "Time 6": 15,
+              "Time 7": 16,
+              "Value #Indexer CPU": 6,
+              "Value #Indexer memory": 5,
+              "Value #Matcher CPU": 4,
+              "Value #Matcher memory": 3,
+              "Value #Organization": 12,
+              "Value #ScannerV2 CPU": 2,
+              "Value #ScannerV2 memory": 1,
               "namespace": 0,
-              "rhacs_org_id": 5,
-              "rhacs_org_name": 4
+              "rhacs_org_name": 7,
+              "rhacs_version": 8
             },
             "renameByName": {
               "Time": "",
+              "Time 7": "",
               "Value": "CPU consumption",
               "Value #A": "",
               "Value #CPU Throttle": "CPU throttle",
               "Value #CPU consumption": "CPU consumption",
               "Value #CPU throttle": "CPU throttle",
+              "Value #Indexer CPU": "Indexer CPU",
+              "Value #Indexer memory": "Indexer memory",
+              "Value #Matcher CPU": "Matcher CPU",
+              "Value #Matcher memory": "Matcher memory",
               "Value #Memory consumption": "Memory consumption",
               "Value #Network Transmitted": "Network transmitted",
               "Value #Network received": "Network received",
               "Value #Organisation": "",
               "Value #Organization": "",
+              "Value #ScannerV2 CPU": "ScannerV2 CPU",
+              "Value #ScannerV2 memory": "ScannerV2 memory",
               "namespace": "Namespace",
               "rhacs_org_id": "Organization ID",
-              "rhacs_org_name": "Organization"
+              "rhacs_org_name": "Organization",
+              "rhacs_version": "Version"
             }
           }
         }

--- a/resources/prometheus/federation-config.yaml
+++ b/resources/prometheus/federation-config.yaml
@@ -21,6 +21,7 @@ match[]:
   - code_resource:apiserver_request_total:rate5m{job!~"central|scanner"}
   - container_cpu_cfs_periods_total{job!~"central|scanner"}
   - container_cpu_cfs_throttled_periods_total{job!~"central|scanner"}
+  - container_cpu_usage_seconds_total{job!~"central|scanner"}
   - container_fs_reads_bytes_total{job!~"central|scanner"}
   - container_fs_reads_total{job!~"central|scanner"}
   - container_fs_writes_bytes_total{job!~"central|scanner"}


### PR DESCRIPTION
- Add ScannerV4 components to Scanner Overview Table (Located at `Dashboards -> rhacs-observability -> RHACS Dataplane - Cluster Metrics`)
- Improve correctness for memory calculation
- Drop Network received/transmitted because it is already displayed on the same page on time series manner
- Add ACS Version
- Use selected range for CPU rate calculation
- Mark deleted instances which had metrics in the selected time range
- Other minor tweaks

Example of applied changes on test environment:
![image](https://github.com/stackrox/rhacs-observability-resources/assets/9057384/11ecd7d8-58eb-40ad-a59f-f545c4c03edd)
