### PR TITLE
fix: automerge action

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,6 +1,9 @@
 name: automerge
 on:
   pull_request:
+    branches:
+      - stage
+      - production
     types:
       - labeled
       - unlabeled

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,30 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.2"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_METHOD: merge
+          MERGE_FILTER_AUTHOR: github-actions

--- a/.github/workflows/sync-prod-from-stage.yaml
+++ b/.github/workflows/sync-prod-from-stage.yaml
@@ -10,10 +10,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Opening pull request
         id: pull
-        # We need main for PULL_REQUEST_AUTO_MERGE_METHOD, which is currently not yet released.
-        uses: tretuna/sync-branches@main
+        uses: tretuna/sync-branches@1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "stage"
           TO_BRANCH: "production"
-          PULL_REQUEST_AUTO_MERGE_METHOD: merge
+          LABELS: automerge

--- a/.github/workflows/sync-stage-from-master.yaml
+++ b/.github/workflows/sync-stage-from-master.yaml
@@ -10,10 +10,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Opening pull request
         id: pull
-        # We need main for PULL_REQUEST_AUTO_MERGE_METHOD, which is currently not yet released.
-        uses: tretuna/sync-branches@main
+        uses: tretuna/sync-branches@1.4.0
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
           TO_BRANCH: "stage"
-          PULL_REQUEST_AUTO_MERGE_METHOD: merge
+          LABELS: automerge


### PR DESCRIPTION
The `PULL_REQUEST_AUTO_MERGE_METHOD` option on the sync action did not seem to work. It did not enable `auto-merge` as expected. Instead, introduce a dedicated automerge action.