### PR TITLE
ROX-23673: Add alerts for cluster autoscaler

### DIFF
--- a/resources/prometheus/federation-config.yaml
+++ b/resources/prometheus/federation-config.yaml
@@ -17,6 +17,9 @@ match[]:
   - cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{job!~"central|scanner"}
   - cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{job!~"central|scanner"}
   - cluster:node_cpu:ratio_rate5m{job!~"central|scanner"}
+  - cluster_autoscaler_cluster_safe_to_autoscale{job!~"central|scanner"}
+  - cluster_autoscaler_skipped_scale_events_count{job!~"central|scanner"}
+  - cluster_autoscaler_unschedulable_pods_count{job!~"central|scanner"}
   - cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{job!~"central|scanner"}
   - code_resource:apiserver_request_total:rate5m{job!~"central|scanner"}
   - container_cpu_cfs_periods_total{job!~"central|scanner"}

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -680,41 +680,23 @@ spec:
             cpu_resource_limits:acscs_worker_nodes:by_availability_zone:sum
             /
             availability_zone:acscs_worker_nodes:allocatable_cpu
-        - alert: WorkerNodesMemoryQuotaOverCommitWarning
-          expr: avg(availability_zone:acscs_worker_nodes:memory_request_ratio) > 0.85
-          for: 5m
+        - alert: WorkerNodesMemoryQuotaOverCommit
+          expr: avg(availability_zone:acscs_worker_nodes:memory_request_ratio) > 0.99
+          for: 15m
           labels:
             severity: warning
           annotations:
             summary: "There is a risk of over-committing Memory resources on worker nodes."
-            description: "During the last 5 minutes, the average memory request commitment on worker nodes was {{ $value | humanizePercentage }}. This is above the recommended threshold of 85%."
+            description: "During the last 15 minutes, the average memory request commitment on worker nodes was {{ $value | humanizePercentage }}. This could make pods unschedulable."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
-        - alert: WorkerNodesMemoryQuotaOverCommit
-          expr: avg(availability_zone:acscs_worker_nodes:memory_request_ratio) > 0.95
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "There is a high risk of over-committing Memory resources on worker nodes."
-            description: "During the last 5 minutes, the average memory request commitment on worker nodes was {{ $value | humanizePercentage }}. This is above the critical threshold of 95%."
-            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
-        - alert: WorkerNodesCPUQuotaOverCommitWarning
-          expr: avg(availability_zone:acscs_worker_nodes:cpu_request_ratio) > 0.85
-          for: 5m
+        - alert: WorkerNodesCPUQuotaOverCommit
+          expr: avg(availability_zone:acscs_worker_nodes:cpu_request_ratio) > 0.1
+          for: 15m
           labels:
             severity: warning
           annotations:
             summary: "There is a risk of over-committing CPU resources on worker nodes."
-            description: "During the last 5 minutes, the average CPU request commitment on worker nodes was {{ $value | humanizePercentage }}. This is above the recommended threshold of 85%."
-            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
-        - alert: WorkerNodesCPUQuotaOverCommit
-          expr: avg(availability_zone:acscs_worker_nodes:cpu_request_ratio) > 0.95
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            summary: "There is a high risk of over-committing CPU resources on worker nodes."
-            description: "During the last 5 minutes, the average CPU request commitment on worker nodes was {{ $value | humanizePercentage }}. This is above the critical threshold of 95%."
+            description: "During the last 15 minutes, the average CPU request commitment on worker nodes was {{ $value | humanizePercentage }}. This could make pods unschedulable."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
         - alert: WorkerNodesMemoryOverCommit
           expr: avg(availability_zone:acscs_worker_nodes:memory_limit_ratio) > 2

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -690,7 +690,7 @@ spec:
             description: "During the last 15 minutes, the average memory request commitment on worker nodes was {{ $value | humanizePercentage }}. This could make pods unschedulable."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
         - alert: WorkerNodesCPUQuotaOverCommit
-          expr: avg(availability_zone:acscs_worker_nodes:cpu_request_ratio) > 0.1
+          expr: avg(availability_zone:acscs_worker_nodes:cpu_request_ratio) > 0.99
           for: 15m
           labels:
             severity: warning

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -725,3 +725,52 @@ spec:
             summary: "There is a high risk of over-committing Memory resources on worker nodes."
             description: "During the last 5 minutes, the average Memory limit commitment on worker nodes was {{ $value | humanizePercentage }}. This is above the recommended threshold of 200%."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
+    - name: cluster-autoscaler
+      rules:
+        # Copied from: https://github.com/openshift/cluster-autoscaler-operator/blob/287595b0ee37b893c02d51d3a461ba118b90c3dc/pkg/controller/clusterautoscaler/monitoring.go#L153
+        # However, different severity levels are used to ensure timely response.
+        # Additional information about alerts: https://github.com/openshift/cluster-autoscaler-operator/blob/287595b0ee37b893c02d51d3a461ba118b90c3dc/docs/user/alerts.md
+        - alert: ClusterAutoscalerUnschedulablePods
+          expr: cluster_autoscaler_unschedulable_pods_count{service="cluster-autoscaler-default"} > 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Cluster Autoscaler has {{ $value }} unschedulable pods."
+            description: "The cluster autoscaler is unable to scale up and is alerting that there are unschedulable pods because of this condition.
+This may be caused by the cluster autoscaler reaching its resources limits, or by Kubernetes waiting for new nodes to become ready."
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"
+        - alert: ClusterAutoscalerNotSafeToScale
+          expr: cluster_autoscaler_cluster_safe_to_autoscale{service="cluster-autoscaler-default"} != 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Cluster Autoscaler is reporting that the cluster is not ready for scaling."
+            description: "The cluster autoscaler has detected that the number of unready nodes is too high
+and it is not safe to continute scaling operations. It makes this determination by checking that the number of ready nodes is greater than the minimum ready count
+(default of 3) and the ratio of unready to ready nodes is less than the maximum unready node percentage (default of 45%). If either of those conditions are not
+true then the cluster autoscaler will enter an unsafe to scale state until the conditions change."
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"
+        - alert: ClusterAutoscalerUnableToScaleCPULimitReached
+          expr: increase(cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="CpuResourceLimit"}[15m]) > 0
+          for: 15m
+          labels:
+            severity: info
+          annotations:
+            summary: "Cluster Autoscaler has reached its maximum CPU core limit and is unable to scale out."
+            description: "The number of total cores in the cluster has exceeded the maximum number set on the
+cluster autoscaler. This is calculated by summing the cpu capacity for all nodes in the cluster and comparing that number against the maximum cores value set for the
+cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler configuration."
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"
+        - alert: ClusterAutoscalerUnableToScaleMemoryLimitReached
+          expr: increase(cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="MemoryResourceLimit"}[15m]) > 0
+          for: 15m
+          labels:
+            severity: info
+          annotations:
+            summary: "Cluster Autoscaler has reached its maximum Memory bytes limit and is unable to scale out."
+            description: "The number of total bytes of RAM in the cluster has exceeded the maximum number set on
+the cluster autoscaler. This is calculated by summing the memory capacity for all nodes in the cluster and comparing that number against the maximum memory bytes value set
+for the cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler configuration."
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"

--- a/resources/prometheus/unit_tests/ClusterAutoscalerNotSafeToScale.yaml
+++ b/resources/prometheus/unit_tests/ClusterAutoscalerNotSafeToScale.yaml
@@ -1,0 +1,37 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_cluster_safe_to_autoscale{service="custom-autoscaler"}
+        values: "0+0x20"
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: ClusterAutoscalerNotSafeToScale
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_cluster_safe_to_autoscale{service="cluster-autoscaler-default"}
+        values: "1+0x20 0+0x20"
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: ClusterAutoscalerNotSafeToScale
+        exp_alerts: []
+      - eval_time: 36m
+        alertname: ClusterAutoscalerNotSafeToScale
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAutoscalerNotSafeToScale
+              severity: warning
+              service: cluster-autoscaler-default
+            exp_annotations:
+              summary: "Cluster Autoscaler is reporting that the cluster is not ready for scaling."
+              description: "The cluster autoscaler has detected that the number of unready nodes is too high
+and it is not safe to continute scaling operations. It makes this determination by checking that the number of ready nodes is greater than the minimum ready count
+(default of 3) and the ratio of unready to ready nodes is less than the maximum unready node percentage (default of 45%). If either of those conditions are not
+true then the cluster autoscaler will enter an unsafe to scale state until the conditions change."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"

--- a/resources/prometheus/unit_tests/ClusterAutoscalerUnableToScaleCPULimitReached.yaml
+++ b/resources/prometheus/unit_tests/ClusterAutoscalerUnableToScaleCPULimitReached.yaml
@@ -1,0 +1,42 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_skipped_scale_events_count{service="custom-autoscaler",direction="up",reason="CpuResourceLimit"}
+        values: "0+0x10 0+1x30"
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="down",reason="CpuResourceLimit"}
+        values: "0+0x10 0+1x30"
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="SomeResourceLimit"}
+        values: "0+0x10 0+1x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ClusterAutoscalerUnableToScaleCPULimitReached
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="CpuResourceLimit"}
+        values: "0+0x10 0+1x30"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ClusterAutoscalerUnableToScaleCPULimitReached
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: ClusterAutoscalerUnableToScaleCPULimitReached
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAutoscalerUnableToScaleCPULimitReached
+              severity: info
+              service: cluster-autoscaler-default
+              direction: up
+              reason: CpuResourceLimit
+            exp_annotations:
+              summary: "Cluster Autoscaler has reached its maximum CPU core limit and is unable to scale out."
+              description: "The number of total cores in the cluster has exceeded the maximum number set on the
+  cluster autoscaler. This is calculated by summing the cpu capacity for all nodes in the cluster and comparing that number against the maximum cores value set for the
+  cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler configuration."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"

--- a/resources/prometheus/unit_tests/ClusterAutoscalerUnableToScaleMemoryLimitReached.yaml
+++ b/resources/prometheus/unit_tests/ClusterAutoscalerUnableToScaleMemoryLimitReached.yaml
@@ -1,0 +1,42 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_skipped_scale_events_count{service="custom-autoscaler",direction="up",reason="MemoryResourceLimit"}
+        values: "0+0x10 0+1x30"
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="down",reason="MemoryResourceLimit"}
+        values: "0+0x10 0+1x30"
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="SomeResourceLimit"}
+        values: "0+0x10 0+1x30"
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ClusterAutoscalerUnableToScaleMemoryLimitReached
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_skipped_scale_events_count{service="cluster-autoscaler-default",direction="up",reason="MemoryResourceLimit"}
+        values: "0+0x10 0+1x30"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ClusterAutoscalerUnableToScaleMemoryLimitReached
+        exp_alerts: []
+      - eval_time: 30m
+        alertname: ClusterAutoscalerUnableToScaleMemoryLimitReached
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAutoscalerUnableToScaleMemoryLimitReached
+              severity: info
+              service: cluster-autoscaler-default
+              direction: up
+              reason: MemoryResourceLimit
+            exp_annotations:
+              summary: "Cluster Autoscaler has reached its maximum Memory bytes limit and is unable to scale out."
+              description: "The number of total bytes of RAM in the cluster has exceeded the maximum number set on
+  the cluster autoscaler. This is calculated by summing the memory capacity for all nodes in the cluster and comparing that number against the maximum memory bytes value set
+  for the cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler configuration."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"

--- a/resources/prometheus/unit_tests/ClusterAutoscalerUnschedulablePods.yaml
+++ b/resources/prometheus/unit_tests/ClusterAutoscalerUnschedulablePods.yaml
@@ -1,0 +1,34 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_unschedulable_pods_count{service="custom-autoscaler"}
+        values: "1+0x40"
+    alert_rule_test:
+      - eval_time: 35m
+        alertname: ClusterAutoscalerUnschedulablePods
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: cluster_autoscaler_unschedulable_pods_count{service="cluster-autoscaler-default"}
+        values: "0+0x20 2+0x50"
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: ClusterAutoscalerUnschedulablePods
+        exp_alerts: []
+      - eval_time: 60m
+        alertname: ClusterAutoscalerUnschedulablePods
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAutoscalerUnschedulablePods
+              severity: critical
+              service: cluster-autoscaler-default
+            exp_annotations:
+              summary: "Cluster Autoscaler has 2 unschedulable pods."
+              description: "The cluster autoscaler is unable to scale up and is alerting that there are unschedulable pods because of this condition. This may be caused by the cluster autoscaler reaching its resources limits, or by Kubernetes waiting for new nodes to become ready."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-041-modify-cluster-autoscaler.md"

--- a/resources/prometheus/unit_tests/WorkerNodesCPUQuotaOverCommit.yaml
+++ b/resources/prometheus/unit_tests/WorkerNodesCPUQuotaOverCommit.yaml
@@ -7,48 +7,24 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1"
+        values: "1+0x20"
       - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1"
+        values: "1+0x20"
       - series: kube_node_status_allocatable{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "100"
+        values: "200+0x20"
       - series: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "86"
-    alert_rule_test:
-      - eval_time: 1m
-        alertname: WorkerNodesCPUQuotaOverCommitWarning
-        exp_alerts: []
-      - eval_time: 5m
-        alertname: WorkerNodesCPUQuotaOverCommitWarning
-        exp_alerts:
-          - exp_labels:
-              alertname: WorkerNodesCPUQuotaOverCommitWarning
-              severity: warning
-            exp_annotations:
-              description: "During the last 5 minutes, the average CPU request commitment on worker nodes was 86%. This is above the recommended threshold of 85%."
-              summary: "There is a risk of over-committing CPU resources on worker nodes."
-              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
-  - interval: 1m
-    input_series:
-      - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1"
-      - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1"
-      - series: kube_node_status_allocatable{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "100"
-      - series: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "96"
+        values: "199+0x20"
     alert_rule_test:
       - eval_time: 1m
         alertname: WorkerNodesCPUQuotaOverCommit
         exp_alerts: []
-      - eval_time: 5m
+      - eval_time: 16m
         alertname: WorkerNodesCPUQuotaOverCommit
         exp_alerts:
           - exp_labels:
               alertname: WorkerNodesCPUQuotaOverCommit
-              severity: critical
+              severity: warning
             exp_annotations:
-              description: "During the last 5 minutes, the average CPU request commitment on worker nodes was 96%. This is above the critical threshold of 95%."
-              summary: "There is a high risk of over-committing CPU resources on worker nodes."
+              summary: "There is a risk of over-committing CPU resources on worker nodes."
+              description: "During the last 15 minutes, the average CPU request commitment on worker nodes was 99.5%. This could make pods unschedulable."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"

--- a/resources/prometheus/unit_tests/WorkerNodesCPUQuotaOverCommit.yaml
+++ b/resources/prometheus/unit_tests/WorkerNodesCPUQuotaOverCommit.yaml
@@ -7,18 +7,21 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1+0x20"
+        values: "1+0x40"
       - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1+0x20"
+        values: "1+0x40"
       - series: kube_node_status_allocatable{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "200+0x20"
+        values: "200+0x40"
       - series: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{node="worker-1", resource="cpu", job="kube-state-metrics"}
-        values: "199+0x20"
+        values: "196+0x20 199+0x20"
     alert_rule_test:
       - eval_time: 1m
         alertname: WorkerNodesCPUQuotaOverCommit
         exp_alerts: []
       - eval_time: 16m
+        alertname: WorkerNodesCPUQuotaOverCommit
+        exp_alerts: []
+      - eval_time: 36m
         alertname: WorkerNodesCPUQuotaOverCommit
         exp_alerts:
           - exp_labels:

--- a/resources/prometheus/unit_tests/WorkerNodesMemoryQuotaOverCommit.yaml
+++ b/resources/prometheus/unit_tests/WorkerNodesMemoryQuotaOverCommit.yaml
@@ -7,18 +7,21 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1+0x20"
+        values: "1+0x40"
       - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1+0x20"
+        values: "1+0x40"
       - series: kube_node_status_allocatable{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "200+0x20"
+        values: "200+0x40"
       - series: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "199+0x20"
+        values: "196+0x20 199+0x20"
     alert_rule_test:
       - eval_time: 1m
         alertname: WorkerNodesMemoryQuotaOverCommit
         exp_alerts: []
       - eval_time: 16m
+        alertname: WorkerNodesMemoryQuotaOverCommit
+        exp_alerts: []
+      - eval_time: 36m
         alertname: WorkerNodesMemoryQuotaOverCommit
         exp_alerts:
           - exp_labels:

--- a/resources/prometheus/unit_tests/WorkerNodesMemoryQuotaOverCommit.yaml
+++ b/resources/prometheus/unit_tests/WorkerNodesMemoryQuotaOverCommit.yaml
@@ -7,48 +7,24 @@ tests:
   - interval: 1m
     input_series:
       - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1"
+        values: "1+0x20"
       - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1"
+        values: "1+0x20"
       - series: kube_node_status_allocatable{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "100"
+        values: "200+0x20"
       - series: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "86"
-    alert_rule_test:
-      - eval_time: 1m
-        alertname: WorkerNodesMemoryQuotaOverCommitWarning
-        exp_alerts: []
-      - eval_time: 5m
-        alertname: WorkerNodesMemoryQuotaOverCommitWarning
-        exp_alerts:
-          - exp_labels:
-              alertname: WorkerNodesMemoryQuotaOverCommitWarning
-              severity: warning
-            exp_annotations:
-              description: "During the last 5 minutes, the average memory request commitment on worker nodes was 86%. This is above the recommended threshold of 85%."
-              summary: "There is a risk of over-committing Memory resources on worker nodes."
-              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"
-  - interval: 1m
-    input_series:
-      - series: kube_node_role{node="worker-1", role="acscs-worker"}
-        values: "1"
-      - series: kube_node_labels{node="worker-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1a"}
-        values: "1"
-      - series: kube_node_status_allocatable{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "100"
-      - series: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{node="worker-1", resource="memory", job="kube-state-metrics"}
-        values: "96"
+        values: "199+0x20"
     alert_rule_test:
       - eval_time: 1m
         alertname: WorkerNodesMemoryQuotaOverCommit
         exp_alerts: []
-      - eval_time: 5m
+      - eval_time: 16m
         alertname: WorkerNodesMemoryQuotaOverCommit
         exp_alerts:
           - exp_labels:
               alertname: WorkerNodesMemoryQuotaOverCommit
-              severity: critical
+              severity: warning
             exp_annotations:
-              description: "During the last 5 minutes, the average memory request commitment on worker nodes was 96%. This is above the critical threshold of 95%."
-              summary: "There is a high risk of over-committing Memory resources on worker nodes."
+              summary: "There is a risk of over-committing Memory resources on worker nodes."
+              description: "During the last 15 minutes, the average memory request commitment on worker nodes was 99.5%. This could make pods unschedulable."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-027-cluster-scale-up.md"


### PR DESCRIPTION
This PR adds alerts related to cluster autoscaler behavior, and it removes alerts related to previous manual scaling.

Alerts are taken from default Openshift operator alerts: https://github.com/openshift/cluster-autoscaler-operator/blob/287595b0ee37b893c02d51d3a461ba118b90c3dc/pkg/controller/clusterautoscaler/monitoring.go#L153

Additional documentation related to alerts can be found here: https://github.com/openshift/cluster-autoscaler-operator/blob/287595b0ee37b893c02d51d3a461ba118b90c3dc/docs/user/alerts.md

They have different levels.
