### PR TITLE
chore(deps): bump grafana to 10.4.0

### DIFF
--- a/resources/index.json
+++ b/resources/index.json
@@ -50,7 +50,7 @@
         "grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml",
         "grafana/generated/dashboards/rhacs-cluster-resource-adjustment-dashboard.yaml"
       ],
-      "grafanaVersion": "10.2.0"
+      "grafanaVersion": "10.4.0"
     },
     "promtail": {
       "enabled": false,


### PR DESCRIPTION
routine Grafana update, see changelog for changes https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v10-4/. The next version will be a major version bump to `11.x`.