### PR TITLE
ROX-23900: Add prometheus alert for SELinux violations

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -756,3 +756,13 @@ cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler c
 the cluster autoscaler. This is calculated by summing the memory capacity for all nodes in the cluster and comparing that number against the maximum memory bytes value set
 for the cluster autoscaler. Limits can be adjusted by modifying the cluster autoscaler configuration."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-042-modify-cluster-autoscaler.md"
+        - alert: ClusterAuditSELinuxViolations
+          expr: |
+            selinux_denials_sample_count > 0
+          labels:
+            severity: info
+          annotations:
+            summary: "SELinux Violations occuring on cluster."
+            description: |
+              A cluster node logged {{ $value }} SELinux AVC denial(s) per minute to the audit log.
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-043-selinux-violation.md"

--- a/resources/prometheus/unit_tests/ClusterAuditSELinuxViolations.yaml
+++ b/resources/prometheus/unit_tests/ClusterAuditSELinuxViolations.yaml
@@ -1,0 +1,23 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: selinux_denials_sample_count{namespace="rhacs-cloudwatch"}
+        values: "1x5"
+    alert_rule_test:
+      - eval_time: 70s
+        alertname: ClusterAuditSELinuxViolations
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAuditSELinuxViolations
+              namespace: rhacs-cloudwatch
+              severity: info
+            exp_annotations:
+              summary: "SELinux Violations occuring on cluster."
+              description: |
+                A cluster node logged 1 SELinux AVC denial(s) per minute to the audit log.
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-043-selinux-violation.md"


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/ROX-22148.

1. SOP is currently under review.
2. The ACSCS release which prevents the Scanner violations is scheduled for today.
Could we do the review now and then merge when (1) and (2) are completed?