### PR TITLE
fix: pass labels array as string

### DIFF
--- a/.github/workflows/sync-prod-from-stage.yaml
+++ b/.github/workflows/sync-prod-from-stage.yaml
@@ -16,4 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "stage"
           TO_BRANCH: "production"
-          LABELS: ["automerge"]
+          LABELS: '["automerge"]'

--- a/.github/workflows/sync-stage-from-master.yaml
+++ b/.github/workflows/sync-stage-from-master.yaml
@@ -16,4 +16,4 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
           TO_BRANCH: "stage"
-          LABELS: ["automerge"]
+          LABELS: '["automerge"]'


### PR DESCRIPTION
It seems like the action actually wants the labels array to be passed as a string https://github.com/TreTuna/sync-branches/blob/main/action.yml#L36-L39.