### PR TITLE
ROX-23558: Add Network Policy alert

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -766,3 +766,25 @@ for the cluster autoscaler. Limits can be adjusted by modifying the cluster auto
             description: |
               A cluster node logged {{ $value }} SELinux AVC denial(s) per minute to the audit log.
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-043-selinux-violation.md"
+        - alert: ClusterAuditNetworkPolicyViolations
+          expr: |
+            network_policy_denials_sample_count > 0
+          for: 10m
+          labels:
+            severity: info
+          annotations:
+            summary: "Network Policy Violations occuring on cluster."
+            description: |
+              A cluster node logged Network Policy ACL denial(s) for 10 minutes.
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-044-network-policy-violation.md"
+        - alert: ClusterAuditNetworkPolicyViolations
+          expr: |
+            network_policy_denials_sample_count >= 15
+          for: 1m
+          labels:
+            severity: info
+          annotations:
+            summary: "Network Policy Violations occuring on cluster."
+            description: |
+              A cluster node logged at least {{ $value }} Network Policy ACL denial(s) per minute.
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-044-network-policy-violation.md"

--- a/resources/prometheus/unit_tests/ClusterAuditNetworkPolicyViolations.yaml
+++ b/resources/prometheus/unit_tests/ClusterAuditNetworkPolicyViolations.yaml
@@ -1,0 +1,59 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: network_policy_denials_sample_count{namespace="rhacs-cloudwatch"}
+        values: "15x1"
+    alert_rule_test:
+      - eval_time: 70s
+        alertname: ClusterAuditNetworkPolicyViolations
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAuditNetworkPolicyViolations
+              namespace: rhacs-cloudwatch
+              severity: info
+            exp_annotations:
+              summary: "Network Policy Violations occuring on cluster."
+              description: |
+                A cluster node logged at least 15 Network Policy ACL denial(s) per minute.
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-044-network-policy-violation.md"
+
+  - interval: 1m
+    input_series:
+      - series: network_policy_denials_sample_count{namespace="rhacs-cloudwatch"}
+        values: "1x10"
+    alert_rule_test:
+      - eval_time: 610s
+        alertname: ClusterAuditNetworkPolicyViolations
+        exp_alerts:
+          - exp_labels:
+              alertname: ClusterAuditNetworkPolicyViolations
+              namespace: rhacs-cloudwatch
+              severity: info
+            exp_annotations:
+              summary: "Network Policy Violations occuring on cluster."
+              description: |
+                A cluster node logged Network Policy ACL denial(s) for 10 minutes.
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-044-network-policy-violation.md"
+
+  - interval: 1m
+    input_series:
+      - series: network_policy_denials_sample_count{namespace="rhacs-cloudwatch"}
+        values: "1x9 0"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: ClusterAuditNetworkPolicyViolations
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: network_policy_denials_sample_count{namespace="rhacs-cloudwatch"}
+        values: "14x1"
+    alert_rule_test:
+      - eval_time: 70s
+        alertname: ClusterAuditNetworkPolicyViolations
+        exp_alerts: []


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/ROX-22148.

The SOP is ~~currently under review~~ merged.

Currently we don't expect to have a zero-baseline for network policy violations until GA, hence this PR aims to allow the current non-zero behaviour.

The behaviour we currently observe is related to "probe namespaces", which are short-lived and cause -- for a "short" period of time -- a "small" amount of violations. I have decided to implement to two different alerting triggers:

1. One, which triggers directly in case the violations cross a certain threshold (per minute), currently set to 15 violations per minute.
2. One, which triggers if any positive amount of violations has been observed for longer than 10 minutes.

Would be great if we could do the review in parallel to the other currently ongoing reviews (plus the ACSCS release scheduled for today).
