### PR TITLE
ROX-24822: Fix acs-cs annotations

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-central-slo-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-central-slo-configmap.yaml
@@ -37,7 +37,7 @@ data:
             },
             "enable": true,
             "iconColor": "purple",
-            "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+            "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
             "name": "Kubernetes Upgrade",
             "textFormat": "Kubernetes Upgrade"
           },
@@ -48,7 +48,7 @@ data:
             },
             "enable": true,
             "iconColor": "red",
-            "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+            "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
             "name": "OpenShift Upgrade",
             "textFormat": "OpenShift Upgrade"
           }

--- a/resources/grafana/generated/dashboards/rhacs-central-slo-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-central-slo-dashboard.yaml
@@ -37,7 +37,7 @@ spec:
             },
             "enable": true,
             "iconColor": "purple",
-            "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+            "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
             "name": "Kubernetes Upgrade",
             "textFormat": "Kubernetes Upgrade"
           },
@@ -48,7 +48,7 @@ spec:
             },
             "enable": true,
             "iconColor": "red",
-            "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+            "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
             "name": "OpenShift Upgrade",
             "textFormat": "OpenShift Upgrade"
           }

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-configmap.yaml
@@ -37,7 +37,7 @@ data:
             },
             "enable": true,
             "iconColor": "purple",
-            "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+            "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
             "name": "Kubernetes Upgrade",
             "textFormat": "Kubernetes Upgrade"
           },
@@ -48,7 +48,7 @@ data:
             },
             "enable": true,
             "iconColor": "red",
-            "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+            "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
             "name": "OpenShift Upgrade",
             "textFormat": "OpenShift Upgrade"
           }

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview-dashboard.yaml
@@ -37,7 +37,7 @@ spec:
             },
             "enable": true,
             "iconColor": "purple",
-            "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+            "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
             "name": "Kubernetes Upgrade",
             "textFormat": "Kubernetes Upgrade"
           },
@@ -48,7 +48,7 @@ spec:
             },
             "enable": true,
             "iconColor": "red",
-            "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+            "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
             "name": "OpenShift Upgrade",
             "textFormat": "OpenShift Upgrade"
           }

--- a/resources/grafana/sources/rhacs-central-slo.json
+++ b/resources/grafana/sources/rhacs-central-slo.json
@@ -26,7 +26,7 @@
         },
         "enable": true,
         "iconColor": "purple",
-        "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+        "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
         "name": "Kubernetes Upgrade",
         "textFormat": "Kubernetes Upgrade"
       },
@@ -37,7 +37,7 @@
         },
         "enable": true,
         "iconColor": "red",
-        "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+        "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
         "name": "OpenShift Upgrade",
         "textFormat": "OpenShift Upgrade"
       }

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -26,7 +26,7 @@
         },
         "enable": true,
         "iconColor": "purple",
-        "expr": "count (count by (git_version) (label_replace(kubernetes_build_info{job!~\"kube-dns|coredns\"}, \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
+        "expr": "count (count by (git_version) (label_replace(count_over_time(kubernetes_build_info{job!~\"kube-dns|coredns\"}[${__interval}]), \"git_version\", \"$1\", \"git_version\", \"(v[0-9]*.[0-9]*).*\"))) > 1",
         "name": "Kubernetes Upgrade",
         "textFormat": "Kubernetes Upgrade"
       },
@@ -37,7 +37,7 @@
         },
         "enable": true,
         "iconColor": "red",
-        "expr": "count (count by (gitVersion) (openshift_apiserver_build_info)) > 1",
+        "expr": "count (count by (gitVersion) (count_over_time (openshift_apiserver_build_info[${__interval}]))) > 1",
         "name": "OpenShift Upgrade",
         "textFormat": "OpenShift Upgrade"
       }


### PR DESCRIPTION
Fixing the missing annotations in ACS-CS dashboards. Switching to `count_over_time`

https://grafana-route-rhacs-observability.apps.acs-int-us-01.isbr.p1.openshiftapps.com/d/4032f3c17643119901e107a0a1786d5b9e4c9565/rhacs-dataplane-cluster-metrics?orgId=1&from=now-90d&to=now

<img width="1133" alt="Screenshot 2024-06-18 at 9 34 35 AM" src="https://github.com/stackrox/rhacs-observability-resources/assets/38968/8f8eea34-6d2c-4462-867b-078090c2ad8b">
