### PR TITLE
chore: bump mixins

### DIFF
--- a/resources/grafana/mixins/kubernetes/apiserver.yaml
+++ b/resources/grafana/mixins/kubernetes/apiserver.yaml
@@ -9,21 +9,13 @@ spec:
   name: kubernetes-mixin-apiserver.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
        "panels": [
           {
-             "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
-             "datasource": null,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "description": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
              "gridPos": {
                 "h": 2,
@@ -31,1451 +23,794 @@ spec:
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "mode": "markdown",
-             "span": 12,
+             "id": 1,
+             "options": {
+                "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
+             },
+             "pluginVersion": "v11.0.0",
              "title": "Notice",
              "type": "text"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 3,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 2
+             },
+             "id": 2,
+             "interval": "1m",
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}"
+                }
+             ],
+             "title": "Availability (30d) > 99.000%",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How much error budget is left looking at our 0.990% availability guarantees?",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 100
+                   },
+                   "decimals": 3,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 16,
+                "x": 8,
+                "y": 2
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
+                   "legendFormat": "errorbudget"
+                }
+             ],
+             "title": "ErrorBudget (30d) > 99.000%",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 3,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 0,
+                "y": 9
+             },
+             "id": 4,
+             "interval": "1m",
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}"
+                }
+             ],
+             "title": "Read Availability (30d)",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 100,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   },
+                   "unit": "reqps"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/2../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#56A64B"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/3../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#F2CC0C"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/4../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#3274D9"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/5../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#E02F44"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 6,
+                "y": 9
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                   "legendFormat": "{{ code }}"
+                }
+             ],
+             "title": "Read SLI - Requests",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 9
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                   "legendFormat": "{{ resource }}"
+                }
+             ],
+             "title": "Read SLI - Errors",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 9
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
+                   "legendFormat": "{{ resource }}"
+                }
+             ],
+             "title": "Read SLI - Duration",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
+             "fieldConfig": {
+                "defaults": {
+                   "decimals": 3,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 0,
+                "y": 16
+             },
+             "id": 8,
+             "interval": "1m",
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}"
+                }
+             ],
+             "title": "Write Availability (30d)",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 100,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   },
+                   "unit": "reqps"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/2../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#56A64B"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/3../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#F2CC0C"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/4../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#3274D9"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/5../i"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": "#E02F44"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 6,
+                "y": 16
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                   "legendFormat": "{{ code }}"
+                }
+             ],
+             "title": "Write SLI - Requests",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 16
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                   "legendFormat": "{{ resource }}"
+                }
+             ],
+             "title": "Write SLI - Errors",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 16
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
+                   "legendFormat": "{{ resource }}"
+                }
+             ],
+             "title": "Write SLI - Duration",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 23
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": false
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(workqueue_adds_total{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                   "legendFormat": "{{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Add Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 23
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": false
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(workqueue_depth{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                   "legendFormat": "{{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Depth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 30
+             },
+             "id": 14,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
+                   "legendFormat": "{{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Latency",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 37
+             },
+             "id": 15,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "process_resident_memory_bytes{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Memory",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "min": 0,
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 37
+             },
+             "id": 16,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "rate(process_cpu_seconds_total{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "CPU usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 37
+             },
+             "id": 17,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "go_goroutines{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Goroutines",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "decimals": 3,
-                   "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
-                   "format": "percentunit",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
-                   },
-                   "gridPos": { },
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 4,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Availability (30d) > 99.000%",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "avg"
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "decimals": 3,
-                   "description": "How much error budget is left looking at our 0.990% availability guarantees?",
-                   "fill": 10,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 8,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "errorbudget",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "ErrorBudget (30d) > 99.000%",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "decimals": 3,
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "decimals": 3,
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "decimals": 3,
-                   "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
-                   "format": "percentunit",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
-                   },
-                   "gridPos": { },
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 3,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Read Availability (30d)",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "avg"
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
-                   "fill": 10,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [
-                      {
-                         "alias": "/2../i",
-                         "color": "#56A64B"
-                      },
-                      {
-                         "alias": "/3../i",
-                         "color": "#F2CC0C"
-                      },
-                      {
-                         "alias": "/4../i",
-                         "color": "#3274D9"
-                      },
-                      {
-                         "alias": "/5../i",
-                         "color": "#E02F44"
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ code }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Read SLI - Requests",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "reqps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "reqps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ resource }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Read SLI - Errors",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ resource }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Read SLI - Duration",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "decimals": 3,
-                   "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
-                   "format": "percentunit",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
-                   },
-                   "gridPos": { },
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 3,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Write Availability (30d)",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "avg"
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
-                   "fill": 10,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [
-                      {
-                         "alias": "/2../i",
-                         "color": "#56A64B"
-                      },
-                      {
-                         "alias": "/3../i",
-                         "color": "#F2CC0C"
-                      },
-                      {
-                         "alias": "/4../i",
-                         "color": "#3274D9"
-                      },
-                      {
-                         "alias": "/5../i",
-                         "color": "#E02F44"
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ code }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Write SLI - Requests",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "reqps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "reqps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ resource }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Write SLI - Errors",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{ resource }}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Write SLI - Duration",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": false,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(workqueue_adds_total{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Add Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 14,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": false,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(workqueue_depth{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Depth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 15,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Latency",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 16,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "process_resident_memory_bytes{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 17,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "rate(process_cpu_seconds_total{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 18,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "go_goroutines{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Goroutines",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          }
-       ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1483,57 +818,42 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"api\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
                 "name": "instance",
-                "options": [ ],
                 "query": "label_values(up{job=\"api\", cluster=\"$cluster\"}, instance)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1541,33 +861,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / API server",
-       "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
-       "version": 0
+       "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b"
     }

--- a/resources/grafana/mixins/kubernetes/cluster-total.yaml
+++ b/resources/grafana/mixins/kubernetes/cluster-total.yaml
@@ -9,1653 +9,783 @@ spec:
   name: kubernetes-mixin-cluster-total.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [
-             {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-             }
-          ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
+       "editable": false,
        "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 0
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 2,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Current Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 1
+                "y": 0
              },
-             "id": 3,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{namespace}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Received",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 1
+                "y": 0
              },
-             "id": 4,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{namespace}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Transmitted",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "columns": [
-                {
-                   "text": "Time",
-                   "value": "Time"
-                },
-                {
-                   "text": "Value #A",
-                   "value": "Value #A"
-                },
-                {
-                   "text": "Value #B",
-                   "value": "Value #B"
-                },
-                {
-                   "text": "Value #C",
-                   "value": "Value #C"
-                },
-                {
-                   "text": "Value #D",
-                   "value": "Value #D"
-                },
-                {
-                   "text": "Value #E",
-                   "value": "Value #E"
-                },
-                {
-                   "text": "Value #F",
-                   "value": "Value #F"
-                },
-                {
-                   "text": "Value #G",
-                   "value": "Value #G"
-                },
-                {
-                   "text": "Value #H",
-                   "value": "Value #H"
-                },
-                {
-                   "text": "namespace",
-                   "value": "namespace"
-                }
-             ],
-             "datasource": "$datasource",
-             "fill": 1,
-             "fontSize": "90%",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bytes/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "binBps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down",
+                                  "url": "/d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
              "gridPos": {
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 9
              },
-             "id": 5,
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null as zero",
-             "renderer": "flot",
-             "scroll": true,
-             "showHeader": true,
-             "sort": {
-                "col": 0,
-                "desc": false
-             },
-             "spaceLength": 10,
-             "span": 24,
-             "styles": [
-                {
-                   "alias": "Time",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Time",
-                   "thresholds": [ ],
-                   "type": "hidden",
-                   "unit": "short"
-                },
-                {
-                   "alias": "Current Bandwidth Received",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #A",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Current Bandwidth Transmitted",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #B",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Average Bandwidth Received",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #C",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Average Bandwidth Transmitted",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #D",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Rate of Received Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #E",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #F",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Received Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #G",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #H",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Namespace",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": true,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=$__cell",
-                   "pattern": "namespace",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "short"
-                }
-             ],
+             "id": 3,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "A",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "B",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "C",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "D",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "E",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "F",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "G",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "H",
-                   "step": 10
+                   "instant": true
                 }
              ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Status",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "namespace",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true,
+                         "Time 8": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Time 8": 7,
+                         "Value #A": 9,
+                         "Value #B": 10,
+                         "Value #C": 11,
+                         "Value #D": 12,
+                         "Value #E": 13,
+                         "Value #F": 14,
+                         "Value #G": 15,
+                         "Value #H": 16,
+                         "namespace": 8
+                      },
+                      "renameByName": {
+                         "Value #A": "Rx Bytes",
+                         "Value #B": "Tx Bytes",
+                         "Value #C": "Rx Bytes (Avg)",
+                         "Value #D": "Tx Bytes (Avg)",
+                         "Value #E": "Rx Packets",
+                         "Value #F": "Tx Packets",
+                         "Value #G": "Rx Packets Dropped",
+                         "Value #H": "Tx Packets Dropped",
+                         "namespace": "Namespace"
+                      }
+                   }
+                }
+             ],
              "type": "table"
           },
           {
-             "collapse": true,
-             "collapsed": true,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 10
+                "y": 18
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Rate of Bytes Received",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 18
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Rate of Bytes Transmitted",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 27
              },
              "id": 6,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 11
-                   },
-                   "id": 7,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Received",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 11
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 8,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Transmitted",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 27
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 11
+                "y": 36
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 36
              },
              "id": 9,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth History",
-             "titleSize": "h6",
-             "type": "row"
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
              "gridPos": {
                 "h": 9,
-                "w": 24,
+                "w": 12,
                 "x": 0,
-                "y": 12
+                "y": 45
              },
              "id": 10,
-             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{namespace}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Receive Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
              "gridPos": {
                 "h": 9,
-                "w": 24,
-                "x": 0,
-                "y": 21
+                "w": 12,
+                "x": 12,
+                "y": 45
              },
              "id": 11,
-             "legend": {
-                "alignAsTable": true,
-                "avg": true,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": true,
-                "min": true,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{namespace}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Transmit Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "percentunit"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 30
+                "y": 54
              },
              "id": 12,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 31
-                   },
-                   "id": 13,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 40
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 14,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum by (instance) (rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[5m]) / rate(node_netstat_Tcp_OutSegs{cluster=\"$cluster\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Packets",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of TCP Retransmits out of all sent segments",
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 31
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 15,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 50
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
                    },
-                   "id": 16,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 54
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 59
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 17,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{namespace}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 59
-                   },
-                   "id": 18,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [
-                      {
-                         "targetBlank": true,
-                         "title": "What is TCP Retransmit?",
-                         "url": "https://accedian.com/enterprises/blog/network-packet-loss-retransmissions-and-duplicate-acknowledgements/"
-                      }
-                   ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_OutSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of TCP Retransmits out of all sent segments",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 24,
-                      "x": 0,
-                      "y": 59
-                   },
-                   "id": 19,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [
-                      {
-                         "targetBlank": true,
-                         "title": "Why monitor SYN retransmits?",
-                         "url": "https://github.com/prometheus/node_exporter/issues/1023#issuecomment-408128365"
-                      }
-                   ],
-                   "minSpan": 24,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(rate(node_netstat_TcpExt_TCPSynRetrans{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of TCP SYN Retransmits out of all retransmits",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum by (instance) (rate(node_netstat_TcpExt_TCPSynRetrans{cluster=\"$cluster\"}[5m]) / rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Errors",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of TCP SYN Retransmits out of all retransmits",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 18,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
        "templating": {
           "list": [
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "resolution",
-                "options": [
-                   {
-                      "selected": false,
-                      "text": "30s",
-                      "value": "30s"
-                   },
-                   {
-                      "selected": true,
-                      "text": "5m",
-                      "value": "5m"
-                   },
-                   {
-                      "selected": false,
-                      "text": "1h",
-                      "value": "1h"
-                   }
-                ],
-                "query": "30s,5m,1h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "interval",
-                "options": [
-                   {
-                      "selected": true,
-                      "text": "4h",
-                      "value": "4h"
-                   }
-                ],
-                "query": "4h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              }
           ]
        },
@@ -1663,33 +793,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Networking / Cluster",
-       "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
-       "version": 0
+       "uid": "ff635a025bcfea7bc3dd4f508990a3e9"
     }

--- a/resources/grafana/mixins/kubernetes/controller-manager.yaml
+++ b/resources/grafana/mixins/kubernetes/controller-manager.yaml
@@ -9,943 +9,529 @@ spec:
   name: kubernetes-mixin-controller-manager.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "none"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 4,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "format": "none",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "gridPos": { },
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
+                   "expr": "sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Up",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 20,
+                "x": 4,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 2,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Up",
-                   "tooltip": {
-                      "shared": false
+                   "expr": "sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
+                   "legendFormat": "{{cluster}} {{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Add Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 7
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "valueName": "min"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
+                   "legendFormat": "{{cluster}} {{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Depth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name, le))",
+                   "legendFormat": "{{cluster}} {{instance}} {{name}}"
+                }
+             ],
+             "title": "Work Queue Latency",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 21
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                   "legendFormat": "2xx"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 10,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Add Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Depth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Work Queue Latency",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "2xx",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "3xx",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "4xx",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "5xx",
-                         "refId": "D"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Kube API Request Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                   "legendFormat": "3xx"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 8,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Post Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Get Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                   "legendFormat": "4xx"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Goroutines",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                   "legendFormat": "5xx"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Kube API Request Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 16,
+                "x": 8,
+                "y": 21
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Post Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Get Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 35
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Memory",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 35
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "CPU usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 35
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Goroutines",
+             "type": "timeseries"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -953,57 +539,43 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-controller-manager\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "instance",
                 "name": "instance",
-                "options": [ ],
                 "query": "label_values(up{cluster=\"$cluster\", job=\"kube-controller-manager\"}, instance)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1011,33 +583,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Controller Manager",
-       "uid": "72e0e05bef5099e5f049b05fdc429ed4",
-       "version": 0
+       "uid": "72e0e05bef5099e5f049b05fdc429ed4"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-cluster.yaml
@@ -9,2600 +9,1526 @@ spec:
   name: kubernetes-mixin-k8s-resources-cluster.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "100px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "none"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Utilisation",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Requests Commitment",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Limits Commitment",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Utilisation",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Requests Commitment",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 2,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Limits Commitment",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Headlines",
-             "titleSize": "h6"
+             "title": "CPU Utilisation",
+             "type": "stat"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 4,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "CPU",
-             "titleSize": "h6"
+             "title": "CPU Requests Commitment",
+             "type": "stat"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 8,
+                "y": 0
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Pods",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Workloads",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to workloads",
-                         "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #G",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Namespace",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                         "pattern": "namespace",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "G"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "title": "CPU Limits Commitment",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 12,
+                "y": 0
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Memory Utilisation",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 16,
+                "y": 0
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Memory Requests Commitment",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 4,
+                "x": 20,
+                "y": 0
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Memory Limits Commitment",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   }
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 6
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "CPU Usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 12
+             },
+             "id": 8,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage (w/o cache)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "namespace",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Value #A": 8,
+                         "Value #B": 9,
+                         "Value #C": 10,
+                         "Value #D": 11,
+                         "Value #E": 12,
+                         "Value #F": 13,
+                         "Value #G": 14,
+                         "namespace": 7
+                      },
+                      "renameByName": {
+                         "Value #A": "Pods",
+                         "Value #B": "Workloads",
+                         "Value #C": "CPU Usage",
+                         "Value #D": "CPU Requests",
+                         "Value #E": "CPU Requests %",
+                         "Value #F": "CPU Limits",
+                         "Value #G": "CPU Limits %",
+                         "namespace": "Namespace"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 18
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
              "title": "Memory",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Memory Usage"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "bytes"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Memory Requests"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "bytes"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Memory Limits"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "bytes"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 24
+             },
+             "id": 10,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Pods",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Workloads",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to workloads",
-                         "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Memory Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #G",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Namespace",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                         "pattern": "namespace",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      },
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "G"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Requests by Namespace",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Memory Requests",
-             "titleSize": "h6"
+             "title": "Memory Requests by Namespace",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "namespace",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Value #A": 8,
+                         "Value #B": 9,
+                         "Value #C": 10,
+                         "Value #D": 11,
+                         "Value #E": 12,
+                         "Value #F": 13,
+                         "Value #G": 14,
+                         "namespace": 7
+                      },
+                      "renameByName": {
+                         "Value #A": "Pods",
+                         "Value #B": "Workloads",
+                         "Value #C": "Memory Usage",
+                         "Value #D": "Memory Requests",
+                         "Value #E": "Memory Requests %",
+                         "Value #F": "Memory Limits",
+                         "Value #G": "Memory Limits %",
+                         "namespace": "Namespace"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bandwidth/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 30
+             },
+             "id": 11,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Current Receive Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Current Transmit Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Namespace",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                         "pattern": "namespace",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Network Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "Current Network Usage",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Receive Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "namespace",
+                      "mode": "outer"
+                   }
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Transmit Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "namespace": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "Current Receive Bandwidth",
+                         "Value #B": "Current Transmit Bandwidth",
+                         "Value #C": "Rate of Received Packets",
+                         "Value #D": "Rate of Transmitted Packets",
+                         "Value #E": "Rate of Received Packets Dropped",
+                         "Value #F": "Rate of Transmitted Packets Dropped",
+                         "namespace": "Namespace"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 14,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 36
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Namespace: Received",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 42
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 48
+             },
+             "id": 14,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Container Bandwidth by Namespace: Received",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 54
+             },
+             "id": 15,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Container Bandwidth by Namespace: Transmitted",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 60
+             },
+             "id": 16,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 66
+             },
+             "id": 17,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 72
+             },
+             "id": 18,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 78
+             },
+             "id": 19,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "iops"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 84
+             },
+             "id": 20,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m])))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "IOPS(Reads+Writes)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 90
+             },
+             "id": 21,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "ThroughPut(Read+Write)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/IOPS/"
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "iops"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Throughput/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Namespace"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 96
+             },
+             "id": 22,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 15,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Namespace: Transmitted",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Container Bandwidth by Namespace",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 16,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 17,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 18,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 19,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets Dropped",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "decimals": -1,
-                   "fill": 10,
-                   "id": 20,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m])))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "IOPS(Reads+Writes)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 21,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{namespace}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "ThroughPut(Read+Write)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+                   "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 22,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "sort": {
-                      "col": 4,
-                      "desc": true
-                   },
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "IOPS(Reads)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Reads + Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Throughput(Read)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Read + Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Namespace",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                         "pattern": "namespace",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Storage IO",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO - Distribution",
-             "titleSize": "h6"
+             "title": "Current Storage IO",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "namespace",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "namespace": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "IOPS(Reads)",
+                         "Value #B": "IOPS(Writes)",
+                         "Value #C": "IOPS(Reads + Writes)",
+                         "Value #D": "Throughput(Read)",
+                         "Value #E": "Throughput(Write)",
+                         "Value #F": "Throughput(Read + Write)",
+                         "namespace": "Namespace"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -2610,40 +1536,29 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -2651,33 +1566,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Cluster",
-       "uid": "efa86fd1d0c121a26444b636a3f509a8",
-       "version": 0
+       "uid": "efa86fd1d0c121a26444b636a3f509a8"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-namespace.yaml
@@ -9,2325 +9,1444 @@ spec:
   name: kubernetes-mixin-k8s-resources-namespace.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "100px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Utilisation (from requests)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Utilisation (from limits)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Utilisation (from requests)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "format": "percentunit",
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 3,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
-                         "format": "time_series",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "70,80",
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Utilisation (from limits)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "singlestat",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Headlines",
-             "titleSize": "h6"
+             "title": "CPU Utilisation (from requests)",
+             "type": "stat"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 6,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "quota - requests",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      },
-                      {
-                         "alias": "quota - limits",
-                         "color": "#FF9830",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "title": "CPU Utilisation (from limits)",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 12,
+                "y": 0
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Memory Utilisation (from requests)",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "percentunit"
+                }
+             },
+             "gridPos": {
+                "h": 3,
+                "w": 6,
+                "x": 18,
+                "y": 0
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+                   "instant": true
+                }
+             ],
+             "title": "Memory Utilisation (from limits)",
+             "type": "stat"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   }
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 7
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "legendFormat": "__auto"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+                   "legendFormat": "quota - requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+                   "legendFormat": "quota - limits"
+                }
+             ],
              "title": "CPU Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 6,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "quota - requests",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true
                       },
-                      {
-                         "alias": "quota - limits",
-                         "color": "#FF9830",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Value #A": 6,
+                         "Value #B": 7,
+                         "Value #C": 8,
+                         "Value #D": 9,
+                         "Value #E": 10,
+                         "pod": 5
+                      },
+                      "renameByName": {
+                         "Value #A": "CPU Usage",
+                         "Value #B": "CPU Requests",
+                         "Value #C": "CPU Requests %",
+                         "Value #D": "CPU Limits",
+                         "Value #E": "CPU Limits %",
+                         "pod": "Pod"
                       }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage (w/o cache)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Memory Usage",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Memory Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Usage (RSS)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Cache)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #G",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Swap)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #H",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      },
-                      {
-                         "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "G"
-                      },
-                      {
-                         "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "H"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
+                   "legendFormat": "__auto"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+                   "legendFormat": "quota - requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+                   "legendFormat": "quota - limits"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "title": "Memory Usage (w/o cache)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+             },
+             "id": 8,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Memory Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true,
+                         "Time 8": true
                       },
-                      {
-                         "alias": "Current Receive Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Time 8": 7,
+                         "Value #A": 9,
+                         "Value #B": 10,
+                         "Value #C": 11,
+                         "Value #D": 12,
+                         "Value #E": 13,
+                         "Value #F": 14,
+                         "Value #G": 15,
+                         "Value #H": 16,
+                         "pod": 8
                       },
-                      {
-                         "alias": "Current Transmit Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
+                      "renameByName": {
+                         "Value #A": "Memory Usage",
+                         "Value #B": "Memory Requests",
+                         "Value #C": "Memory Requests %",
+                         "Value #D": "Memory Limits",
+                         "Value #E": "Memory Limits %",
+                         "Value #F": "Memory Usage (RSS)",
+                         "Value #G": "Memory Usage (Cache)",
+                         "Value #H": "Memory Usage (Swap)",
+                         "pod": "Pod"
                       }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Network Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bandwidth/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 35
+             },
+             "id": 9,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Current Network Usage",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Receive Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Transmit Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "pod": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "Current Receive Bandwidth",
+                         "Value #B": "Current Transmit Bandwidth",
+                         "Value #C": "Rate of Received Packets",
+                         "Value #D": "Rate of Transmitted Packets",
+                         "Value #E": "Rate of Received Packets Dropped",
+                         "Value #F": "Rate of Transmitted Packets Dropped",
+                         "pod": "Pod"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 42
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 42
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 49
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 49
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 56
+             },
+             "id": 14,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 56
+             },
+             "id": 15,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "iops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 63
+             },
+             "id": 16,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "IOPS(Reads+Writes)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 63
+             },
+             "id": 17,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "ThroughPut(Read+Write)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/IOPS/"
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "iops"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Throughput/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 70
+             },
+             "id": 18,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 14,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 15,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets Dropped",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "decimals": -1,
-                   "fill": 10,
-                   "id": 16,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "IOPS(Reads+Writes)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 17,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "ThroughPut(Read+Write)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 18,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "sort": {
-                      "col": 4,
-                      "desc": true
+                   "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "IOPS(Reads)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Reads + Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Throughput(Read)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Read + Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Storage IO",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO - Distribution",
-             "titleSize": "h6"
+             "title": "Current Storage IO",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "pod": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "IOPS(Reads)",
+                         "Value #B": "IOPS(Writes)",
+                         "Value #C": "IOPS(Reads + Writes)",
+                         "Value #D": "Throughput(Read)",
+                         "Value #E": "Throughput(Write)",
+                         "Value #F": "Throughput(Read + Write)",
+                         "pod": "Pod"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -2335,63 +1454,42 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -2399,33 +1497,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Namespace (Pods)",
-       "uid": "85a562078cdf77779eaa1add43ccec1e",
-       "version": 0
+       "uid": "85a562078cdf77779eaa1add43ccec1e"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-node.yaml
@@ -9,772 +9,504 @@ spec:
   name: kubernetes-mixin-k8s-resources-node.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   }
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "max capacity"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         },
+                         {
+                            "id": "custom.stacking",
+                            "value": {
+                               "mode": "none"
+                            }
+                         },
+                         {
+                            "id": "custom.hideFrom",
+                            "value": {
+                               "legend": false,
+                               "tooltip": true,
+                               "viz": false
+                            }
+                         },
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "dash": [
+                                  10,
+                                  10
+                               ],
+                               "fill": "dash"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "max capacity",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "max capacity",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
+                   "legendFormat": "max capacity"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "legendFormat": "{{pod}}"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 6
+             },
+             "id": 2,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "max capacity",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "max capacity",
-                         "legendLink": null
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true
                       },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
+                      "renameByName": {
+                         "Value #A": "CPU Usage",
+                         "Value #B": "CPU Requests",
+                         "Value #C": "CPU Requests %",
+                         "Value #D": "CPU Limits",
+                         "Value #E": "CPU Limits %",
+                         "pod": "Pod"
                       }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage (w/o cache)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Memory Usage",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true,
+                      "stacking": {
+                         "mode": "normal"
+                      }
+                   },
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "max capacity"
+                      },
+                      "properties": [
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         },
+                         {
+                            "id": "custom.stacking",
+                            "value": {
+                               "mode": "none"
+                            }
+                         },
+                         {
+                            "id": "custom.hideFrom",
+                            "value": {
+                               "legend": false,
+                               "tooltip": true,
+                               "viz": false
+                            }
+                         },
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "dash": [
+                                  10,
+                                  10
+                               ],
+                               "fill": "dash"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 12
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Memory Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Usage (RSS)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Cache)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #G",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Swap)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #H",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "G"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "H"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
+                   "legendFormat": "max capacity"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
+                   "legendFormat": "{{pod}}"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "title": "Memory Usage (w/o cache)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 6,
+                "w": 24,
+                "x": 0,
+                "y": 18
+             },
+             "id": 4,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Memory Quota",
-             "titleSize": "h6"
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true,
+                         "Time 8": true
+                      },
+                      "renameByName": {
+                         "Value #A": "Memory Usage",
+                         "Value #B": "Memory Requests",
+                         "Value #C": "Memory Requests %",
+                         "Value #D": "Memory Limits",
+                         "Value #E": "Memory Limits %",
+                         "Value #F": "Memory Usage (RSS)",
+                         "Value #G": "Memory Usage (Cache)",
+                         "Value #H": "Memory Usage (Swap)",
+                         "pod": "Pod"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -782,63 +514,42 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
+                "label": "node",
                 "multi": true,
                 "name": "node",
-                "options": [ ],
                 "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -846,33 +557,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Node (Pods)",
-       "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
-       "version": 0
+       "uid": "200ac8fdbfbb74b39aff88118e4d1c2c"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-pod.yaml
@@ -9,2017 +9,1297 @@ spec:
   name: kubernetes-mixin-k8s-resources-pod.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   }
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "requests",
-                         "color": "#F2495C",
-                         "fill": 0,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      },
-                      {
-                         "alias": "limits",
-                         "color": "#FF9830",
-                         "fill": 0,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}) by (container)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{container}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\", container!=\"\"}) by (container)",
+                   "legendFormat": "__auto"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+                   "legendFormat": "requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+                   "legendFormat": "limits"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": true,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{container}}",
-                         "legendLink": null
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "axisColorMode": "thresholds",
+                      "axisSoftMax": 1,
+                      "axisSoftMin": 0,
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true,
+                      "thresholdsStyle": {
+                         "mode": "dashed+area"
                       }
-                   ],
-                   "thresholds": [
-                      {
-                         "colorMode": "critical",
-                         "fill": true,
-                         "line": true,
-                         "op": "gt",
-                         "value": 0.25,
-                         "yaxis": "left"
-                      }
-                   ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Throttling",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "percentunit",
-                         "label": null,
-                         "logBase": 1,
-                         "max": 1,
-                         "min": 0,
-                         "show": true
+                   "unit": "percentunit"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "A"
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                      "properties": [
+                         {
+                            "id": "thresholds",
+                            "value": {
+                               "mode": "absolute",
+                               "steps": [
+                                  {
+                                     "color": "green",
+                                     "value": null
+                                  },
+                                  {
+                                     "color": "red",
+                                     "value": 0.25
+                                  }
+                               ]
+                            }
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "mode": "thresholds",
+                               "seriesBy": "lastNotNull"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 7
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Throttling",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 3,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Container",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "container",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "requests",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "container",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true
                       },
-                      {
-                         "alias": "limits",
-                         "color": "#FF9830",
-                         "dashes": true,
-                         "fill": 0,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Value #A": 6,
+                         "Value #B": 7,
+                         "Value #C": 8,
+                         "Value #D": 9,
+                         "Value #E": 10,
+                         "container": 5
+                      },
+                      "renameByName": {
+                         "Value #A": "CPU Usage",
+                         "Value #B": "CPU Requests",
+                         "Value #C": "CPU Requests %",
+                         "Value #D": "CPU Limits",
+                         "Value #E": "CPU Limits %",
+                         "container": "Container"
                       }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{container}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage (WSS)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Memory Usage",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Memory Usage (WSS)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Usage (RSS)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Cache)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #G",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Usage (Swap)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #H",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Container",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "container",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      },
-                      {
-                         "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "G"
-                      },
-                      {
-                         "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "H"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+                   "legendFormat": "__auto"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+                   "legendFormat": "requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+                   "legendFormat": "limits"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "title": "Memory Usage (WSS)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+             },
+             "id": 5,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Memory Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Receive Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "container",
+                      "mode": "outer"
+                   }
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Transmit Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true,
+                         "Time 8": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Time 8": 7,
+                         "Value #A": 9,
+                         "Value #B": 10,
+                         "Value #C": 11,
+                         "Value #D": 12,
+                         "Value #E": 13,
+                         "Value #F": 14,
+                         "Value #G": 15,
+                         "Value #H": 16,
+                         "container": 8
+                      },
+                      "renameByName": {
+                         "Value #A": "Memory Usage",
+                         "Value #B": "Memory Requests",
+                         "Value #C": "Memory Requests %",
+                         "Value #D": "Memory Limits",
+                         "Value #E": "Memory Limits %",
+                         "Value #F": "Memory Usage (RSS)",
+                         "Value #G": "Memory Usage (Cache)",
+                         "Value #H": "Memory Usage (Swap)",
+                         "container": "Container"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 35
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 35
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 42
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 42
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 49
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 49
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "iops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 56
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+                   "legendFormat": "Reads"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+                   "legendFormat": "Writes"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets",
-             "titleSize": "h6"
+             "title": "IOPS (Pod)",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 56
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+                   "legendFormat": "Reads"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+                   "legendFormat": "Writes"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets Dropped",
-             "titleSize": "h6"
+             "title": "ThroughPut (Pod)",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "decimals": -1,
-                   "fill": 10,
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "Reads",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "Writes",
-                         "legendLink": null
-                      }
+                   "unit": "iops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 63
+             },
+             "id": 14,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "IOPS",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "ceil(sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m])))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "IOPS (Containers)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 63
+             },
+             "id": 15,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "ThroughPut (Containers)",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/IOPS/"
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "iops"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Throughput/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 70
+             },
+             "id": 16,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "Reads",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "Writes",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "ThroughPut",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO - Distribution(Pod - Read & Writes)",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "decimals": -1,
-                   "fill": 10,
-                   "id": 14,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "ceil(sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m])))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{container}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "IOPS(Reads+Writes)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 15,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{container}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "ThroughPut(Read+Write)",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO - Distribution(Containers)",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+                   "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 16,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "sort": {
-                      "col": 4,
-                      "desc": true
+                   "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "IOPS(Reads)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "IOPS(Reads + Writes)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": -1,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Throughput(Read)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Throughput(Read + Write)",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Container",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "container",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Storage IO",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Storage IO - Distribution",
-             "titleSize": "h6"
+             "title": "Current Storage IO",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "container",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "container": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "IOPS(Reads)",
+                         "Value #B": "IOPS(Writes)",
+                         "Value #C": "IOPS(Reads + Writes)",
+                         "Value #D": "Throughput(Read)",
+                         "Value #E": "Throughput(Write)",
+                         "Value #F": "Throughput(Read + Write)",
+                         "container": "Container"
+                      }
+                   }
+                }
+             ],
+             "type": "table"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -2027,86 +1307,55 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "pod",
                 "name": "pod",
-                "options": [ ],
                 "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\"}, pod)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -2114,33 +1363,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Pod",
-       "uid": "6581e46e4e5c7ba40a07646395ef7b23",
-       "version": 0
+       "uid": "6581e46e4e5c7ba40a07646395ef7b23"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workload.yaml
@@ -9,1593 +9,965 @@ spec:
   name: kubernetes-mixin-k8s-resources-workload.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   }
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 7
+             },
+             "id": 2,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Value #A": 6,
+                         "Value #B": 7,
+                         "Value #C": 8,
+                         "Value #D": 9,
+                         "Value #E": 10,
+                         "pod": 5
+                      },
+                      "renameByName": {
+                         "Value #A": "CPU Usage",
+                         "Value #B": "CPU Requests",
+                         "Value #C": "CPU Requests %",
+                         "Value #D": "CPU Limits",
+                         "Value #E": "CPU Limits %",
+                         "pod": "Pod"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "legendFormat": "__auto"
+                }
+             ],
              "title": "Memory Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 4,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Memory Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "Memory Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true
                       },
-                      {
-                         "alias": "Current Receive Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Value #A": 9,
+                         "Value #B": 10,
+                         "Value #C": 11,
+                         "Value #D": 12,
+                         "Value #E": 13,
+                         "pod": 8
                       },
-                      {
-                         "alias": "Current Transmit Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Pod",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                         "pattern": "pod",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
+                      "renameByName": {
+                         "Value #A": "Memory Usage",
+                         "Value #B": "Memory Requests",
+                         "Value #C": "Memory Requests %",
+                         "Value #D": "Memory Limits",
+                         "Value #E": "Memory Limits %",
+                         "pod": "Pod"
                       }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Network Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bandwidth/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to pods",
+                                  "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+             },
+             "id": 5,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Current Network Usage",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Receive Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Transmit Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "pod": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "Current Receive Bandwidth",
+                         "Value #B": "Current Transmit Bandwidth",
+                         "Value #C": "Rate of Received Packets",
+                         "Value #D": "Rate of Transmitted Packets",
+                         "Value #E": "Rate of Received Packets Dropped",
+                         "Value #F": "Rate of Transmitted Packets Dropped",
+                         "pod": "Pod"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 35
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Pod: Received",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Pod: Transmitted",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Container Bandwidth by Pod",
-             "titleSize": "h6"
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 35
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets",
-             "titleSize": "h6"
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 42
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{pod}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets Dropped",
-             "titleSize": "h6"
+             "title": "Average Container Bandwidth by Pod: Received",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 42
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Container Bandwidth by Pod: Transmitted",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 49
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 49
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 56
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 56
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1603,109 +975,69 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "includeAll": true,
+                "label": "workload_type",
                 "name": "type",
-                "options": [ ],
                 "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\"}, workload_type)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "workload",
                 "name": "workload",
-                "options": [ ],
-                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}, workload)",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}, workload)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1713,33 +1045,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Workload",
-       "uid": "a164a7f0339f99e89cea5cb47e9be617",
-       "version": 0
+       "uid": "a164a7f0339f99e89cea5cb47e9be617"
     }

--- a/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
+++ b/resources/grafana/mixins/kubernetes/k8s-resources-workloads-namespace.yaml
@@ -9,1758 +9,1175 @@ spec:
   name: kubernetes-mixin-k8s-resources-workloads-namespace.json
   json: |
     {
-       "annotations": {
-          "list": [ ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "editable": false,
+       "panels": [
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   }
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 1,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "quota - requests",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      },
-                      {
-                         "alias": "quota - limits",
-                         "color": "#FF9830",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
-                      }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}} - {{workload_type}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "legendFormat": "{{workload}} - {{workload_type}}"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+                   "legendFormat": "quota - requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+                   "legendFormat": "quota - limits"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Workload"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to workloads",
+                                  "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                               }
+                            ]
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Running Pods"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "none"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 7
+             },
+             "id": 2,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Running Pods",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "CPU Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "CPU Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Workload",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
-                         "pattern": "workload",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Workload Type",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "workload_type",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "CPU Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [
-                      {
-                         "alias": "quota - requests",
-                         "color": "#F2495C",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "workload",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "workload_type 2": true,
+                         "workload_type 3": true,
+                         "workload_type 4": true,
+                         "workload_type 5": true,
+                         "workload_type 6": true
                       },
-                      {
-                         "alias": "quota - limits",
-                         "color": "#FF9830",
-                         "dashes": true,
-                         "fill": 0,
-                         "hiddenSeries": true,
-                         "hideTooltip": true,
-                         "legend": true,
-                         "linewidth": 2,
-                         "stack": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 8,
+                         "Value #B": 9,
+                         "Value #C": 10,
+                         "Value #D": 11,
+                         "Value #E": 12,
+                         "Value #F": 13,
+                         "workload": 6,
+                         "workload_type 1": 7,
+                         "workload_type 2": 14,
+                         "workload_type 3": 15,
+                         "workload_type 4": 16,
+                         "workload_type 5": 17,
+                         "workload_type 6": 18
+                      },
+                      "renameByName": {
+                         "Value #A": "Running Pods",
+                         "Value #B": "CPU Usage",
+                         "Value #C": "CPU Requests",
+                         "Value #D": "CPU Requests %",
+                         "Value #E": "CPU Limits",
+                         "Value #F": "CPU Limits %",
+                         "workload": "Workload",
+                         "workload_type 1": "Type"
                       }
-                   ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}} - {{workload_type}}",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - requests",
-                         "legendLink": null
-                      },
-                      {
-                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "quota - limits",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "B"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "red",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byFrameRefID",
+                         "options": "C"
+                      },
+                      "properties": [
+                         {
+                            "id": "custom.lineStyle",
+                            "value": {
+                               "fill": "dash"
+                            }
+                         },
+                         {
+                            "id": "custom.lineWidth",
+                            "value": 2
+                         },
+                         {
+                            "id": "color",
+                            "value": {
+                               "fixedColor": "orange",
+                               "mode": "fixed"
+                            }
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "legendFormat": "{{workload}} - {{workload_type}}"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+                   "legendFormat": "quota - requests"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+                   "legendFormat": "quota - limits"
+                }
+             ],
              "title": "Memory Usage",
-             "titleSize": "h6"
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "bytes"
+                },
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/%/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "percentunit"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Workload"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to workloads",
+                                  "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                               }
+                            ]
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Running Pods"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "none"
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 4,
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
-                      },
-                      {
-                         "alias": "Running Pods",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 0,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Memory Usage",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Requests %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Memory Limits",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "bytes"
-                      },
-                      {
-                         "alias": "Memory Limits %",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "percentunit"
-                      },
-                      {
-                         "alias": "Workload",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
-                         "pattern": "workload",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Workload Type",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "workload_type",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
-                      }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory Quota",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
+                   "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+                   "format": "table",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
              "title": "Memory Quota",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "styles": [
-                      {
-                         "alias": "Time",
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "pattern": "Time",
-                         "type": "hidden"
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "workload",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "workload_type 2": true,
+                         "workload_type 3": true,
+                         "workload_type 4": true,
+                         "workload_type 5": true,
+                         "workload_type 6": true
                       },
-                      {
-                         "alias": "Current Receive Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #A",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 8,
+                         "Value #B": 9,
+                         "Value #C": 10,
+                         "Value #D": 11,
+                         "Value #E": 12,
+                         "Value #F": 13,
+                         "workload": 6,
+                         "workload_type 1": 7,
+                         "workload_type 2": 14,
+                         "workload_type 3": 15,
+                         "workload_type 4": 16,
+                         "workload_type 5": 17,
+                         "workload_type 6": 18
                       },
-                      {
-                         "alias": "Current Transmit Bandwidth",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #B",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "Bps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #C",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #D",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Received Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #E",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Rate of Transmitted Packets Dropped",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "Value #F",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "pps"
-                      },
-                      {
-                         "alias": "Workload",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": true,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down to pods",
-                         "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type",
-                         "pattern": "workload",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "Workload Type",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "link": false,
-                         "linkTargetBlank": false,
-                         "linkTooltip": "Drill down",
-                         "linkUrl": "",
-                         "pattern": "workload_type",
-                         "thresholds": [ ],
-                         "type": "number",
-                         "unit": "short"
-                      },
-                      {
-                         "alias": "",
-                         "colorMode": null,
-                         "colors": [ ],
-                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                         "decimals": 2,
-                         "pattern": "/.*/",
-                         "thresholds": [ ],
-                         "type": "string",
-                         "unit": "short"
+                      "renameByName": {
+                         "Value #A": "Running Pods",
+                         "Value #B": "Memory Usage",
+                         "Value #C": "Memory Requests",
+                         "Value #D": "Memory Requests %",
+                         "Value #E": "Memory Limits",
+                         "Value #F": "Memory Limits %",
+                         "workload": "Workload",
+                         "workload_type 1": "Type"
                       }
-                   ],
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "D"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "E"
-                      },
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "table",
-                         "instant": true,
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "F"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Current Network Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "transform": "table",
-                   "type": "table",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
+             "type": "table"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bandwidth/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Workload"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down to workloads",
+                                  "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 28
+             },
+             "id": 5,
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true
+                }
+             ],
              "title": "Current Network Usage",
-             "titleSize": "h6"
-          },
-          {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
+             "transformations": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Receive Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "workload",
+                      "mode": "outer"
+                   }
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Transmit Bandwidth",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
                       },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "workload": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "Current Receive Bandwidth",
+                         "Value #B": "Current Transmit Bandwidth",
+                         "Value #C": "Rate of Received Packets",
+                         "Value #D": "Rate of Transmitted Packets",
+                         "Value #E": "Rate of Received Packets Dropped",
+                         "Value #F": "Rate of Transmitted Packets Dropped",
+                         "workload": "Workload"
                       }
-                   ]
+                   }
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6"
+             "type": "table"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 35
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Workload: Received",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Container Bandwidth by Workload: Transmitted",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Container Bandwidth by Workload",
-             "titleSize": "h6"
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 35
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets",
-             "titleSize": "h6"
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "height": "250px",
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 42
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 10,
-                   "id": 13,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 0,
-                   "links": [ ],
-                   "nullPointMode": "null as zero",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{workload}}",
-                         "legendLink": null
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": false
-                      }
-                   ]
+                   "expr": "(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Rate of Packets Dropped",
-             "titleSize": "h6"
+             "title": "Average Container Bandwidth by Workload: Received",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 42
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Average Container Bandwidth by Workload: Transmitted",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 49
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 49
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 56
+             },
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 56
+             },
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1768,91 +1185,56 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
-                "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+                "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "deployment",
-                   "value": "deployment"
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "includeAll": true,
+                "label": "workload_type",
                 "name": "type",
-                "options": [ ],
                 "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              }
           ]
        },
@@ -1860,33 +1242,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
-       "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
-       "version": 0
+       "uid": "a87fb0d919ec0ea5f6543124e16c42a5"
     }

--- a/resources/grafana/mixins/kubernetes/kubelet.yaml
+++ b/resources/grafana/mixins/kubernetes/kubelet.yaml
@@ -9,28 +9,15 @@ spec:
   name: kubernetes-mixin-kubelet.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
        "panels": [
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -40,46 +27,32 @@ spec:
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "links": [ ],
+             "id": 1,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(kubelet_node_name{cluster=\"$cluster\", job=\"kubelet\"})",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "A"
+                   "instant": true
                 }
              ],
              "title": "Running Kubelets",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -89,46 +62,32 @@ spec:
                 "x": 4,
                 "y": 0
              },
-             "id": 3,
-             "links": [ ],
+             "id": 2,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(kubelet_running_pods{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_pod_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(kubelet_running_pods{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+                   "instant": true
                 }
              ],
              "title": "Running Pods",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -138,46 +97,32 @@ spec:
                 "x": 8,
                 "y": 0
              },
-             "id": 4,
-             "links": [ ],
+             "id": 3,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(kubelet_running_containers{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_container_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(kubelet_running_containers{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+                   "instant": true
                 }
              ],
              "title": "Running Containers",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -187,46 +132,32 @@ spec:
                 "x": 12,
                 "y": 0
              },
-             "id": 5,
-             "links": [ ],
+             "id": 4,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\", state=\"actual_state_of_world\"})",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "instant": true
                 }
              ],
              "title": "Actual Volume Count",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -236,46 +167,32 @@ spec:
                 "x": 16,
                 "y": 0
              },
-             "id": 6,
-             "links": [ ],
+             "id": 5,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\",state=\"desired_state_of_world\"})",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "instant": true
                 }
              ],
              "title": "Desired Volume Count",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "datasource": "$datasource",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
              "fieldConfig": {
                 "defaults": {
-                   "links": [ ],
-                   "mappings": [ ],
-                   "thresholds": {
-                      "mode": "absolute",
-                      "steps": [ ]
-                   },
                    "unit": "none"
                 }
              },
@@ -285,1613 +202,986 @@ spec:
                 "x": 20,
                 "y": 0
              },
-             "id": 7,
-             "links": [ ],
+             "id": 6,
+             "interval": "1m",
              "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "auto",
-                "orientation": "auto",
-                "reduceOptions": {
-                   "calcs": [
-                      "lastNotNull"
-                   ],
-                   "fields": "",
-                   "values": false
-                },
-                "textMode": "auto"
+                "colorMode": "none"
              },
-             "pluginVersion": "7",
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(kubelet_node_config_error{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m]))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "instant": true
                 }
              ],
              "title": "Config Error Count",
-             "transparent": false,
              "type": "stat"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 0,
                 "y": 7
              },
-             "id": 8,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(kubelet_runtime_operations_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (operation_type, instance)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_type}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_type}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Operation Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 12,
                 "y": 7
              },
-             "id": 9,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(kubelet_runtime_operations_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_type}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_type}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Operation Error Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 24,
                 "x": 0,
                 "y": 14
              },
-             "id": 10,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_type}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_type}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Operation duration 99th quantile",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "title": "Operation Duration 99th quantile",
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 0,
+                "y": 21
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+                   "legendFormat": "{{instance}} pod"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+                   "legendFormat": "{{instance}} worker"
+                }
+             ],
+             "title": "Pod Start Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
                 "y": 21
              },
              "id": 11,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} pod",
-                   "refId": "A"
-                },
-                {
-                   "expr": "sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} worker",
-                   "refId": "B"
-                }
-             ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Pod Start Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
-             "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 21
-             },
-             "id": 12,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
-             },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
-             "targets": [
-                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} pod",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} pod"
                 },
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} worker",
-                   "refId": "B"
+                   "legendFormat": "{{instance}} worker"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Pod Start Duration",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 0,
                 "y": 28
              },
-             "id": 13,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 12,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(storage_operation_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Storage Operation Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 12,
                 "y": 28
              },
-             "id": 14,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 13,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(storage_operation_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Storage Operation Error Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 24,
                 "x": 0,
                 "y": 35
              },
-             "id": 15,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 14,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Storage Operation Duration 99th quantile",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 0,
+                "y": 42
+             },
+             "id": 15,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type)",
+                   "legendFormat": "{{operation_type}}"
+                }
+             ],
+             "title": "Cgroup manager operation rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
                 "y": 42
              },
              "id": 16,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
-             },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
-             "targets": [
-                {
-                   "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{operation_type}}",
-                   "refId": "A"
-                }
-             ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Cgroup manager operation rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
+                "tooltip": {
+                   "mode": "single"
                 }
-             ]
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
-             "gridPos": {
-                "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 42
              },
-             "id": 17,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
-             },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{operation_type}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{operation_type}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Cgroup manager 99th quantile",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "description": "Pod lifecycle event generator",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 0,
                 "y": 49
              },
-             "id": 18,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 17,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(kubelet_pleg_relist_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance)",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "PLEG relist rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 12,
                 "x": 12,
                 "y": 49
              },
-             "id": 19,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 18,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "PLEG relist interval",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 24,
                 "x": 0,
                 "y": 56
              },
-             "id": 20,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 19,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "PLEG relist duration",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 24,
                 "x": 0,
                 "y": 63
              },
-             "id": 21,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 20,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "2xx",
-                   "refId": "A"
+                   "legendFormat": "2xx"
                 },
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "3xx",
-                   "refId": "B"
+                   "legendFormat": "3xx"
                 },
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "4xx",
-                   "refId": "C"
+                   "legendFormat": "4xx"
                 },
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "5xx",
-                   "refId": "D"
+                   "legendFormat": "5xx"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "RPC Rate",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "ops",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "title": "RPC rate",
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 24,
                 "x": 0,
                 "y": 70
              },
-             "id": 22,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": true
+             "id": 21,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, verb, url, le))",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}} {{verb}} {{url}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}} {{verb}} {{url}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Request duration 99th quantile",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "s",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 8,
                 "x": 0,
                 "y": 77
              },
-             "id": 23,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 22,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "process_resident_memory_bytes{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Memory",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "bytes",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "bytes",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 8,
                 "x": 8,
                 "y": 77
              },
-             "id": 24,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 23,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "CPU usage",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "short",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "short",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 1,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
              "gridPos": {
                 "h": 7,
                 "w": 8,
                 "x": 16,
                 "y": 77
              },
-             "id": 25,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 24,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "nullPointMode": "null",
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
                    "expr": "go_goroutines{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
-                   "format": "time_series",
-                   "intervalFactor": 2,
-                   "legendFormat": "{{instance}}",
-                   "refId": "A"
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Goroutines",
-             "tooltip": {
-                "shared": true,
-                "sort": 0,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "short",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                },
-                {
-                   "format": "short",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": null,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1899,57 +1189,42 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
                 "label": "instance",
-                "multi": false,
                 "name": "instance",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",cluster=\"$cluster\"}, instance)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1957,33 +1232,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Kubelet",
-       "uid": "3138fa155d5915769fbded898ac09fd9",
-       "version": 0
+       "uid": "3138fa155d5915769fbded898ac09fd9"
     }

--- a/resources/grafana/mixins/kubernetes/namespace-by-pod.yaml
+++ b/resources/grafana/mixins/kubernetes/namespace-by-pod.yaml
@@ -9,1133 +9,557 @@ spec:
   name: kubernetes-mixin-namespace-by-pod.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [
-             {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-             }
-          ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
+       "editable": false,
        "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "displayName": "$namespace",
+                   "max": 10000000000,
+                   "min": 0,
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "dark-green",
+                            "index": 0,
+                            "value": null
+                         },
+                         {
+                            "color": "dark-yellow",
+                            "index": 1,
+                            "value": 5000000000
+                         },
+                         {
+                            "color": "dark-red",
+                            "index": 2,
+                            "value": 7000000000
+                         }
+                      ]
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Current Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "cacheTimeout": null,
-             "colorBackground": false,
-             "colorValue": false,
-             "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-             ],
-             "datasource": "$datasource",
-             "decimals": 0,
-             "format": "time_series",
-             "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-             },
-             "gridPos": {
-                "h": 9,
-                "w": 12,
-                "x": 0,
-                "y": 1
-             },
-             "height": 9,
-             "id": 3,
-             "interval": null,
-             "links": [ ],
-             "mappingType": 1,
-             "mappingTypes": [
-                {
-                   "name": "value to text",
-                   "value": 1
-                },
-                {
-                   "name": "range to text",
-                   "value": 2
-                }
-             ],
-             "maxDataPoints": 100,
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "nullText": null,
-             "options": {
-                "fieldOptions": {
-                   "calcs": [
-                      "last"
-                   ],
-                   "defaults": {
-                      "max": 10000000000,
-                      "min": 0,
-                      "title": "$namespace",
-                      "unit": "Bps"
-                   },
-                   "mappings": [ ],
-                   "override": { },
-                   "thresholds": [
-                      {
-                         "color": "dark-green",
-                         "index": 0,
-                         "value": null
-                      },
-                      {
-                         "color": "dark-yellow",
-                         "index": 1,
-                         "value": 5000000000
-                      },
-                      {
-                         "color": "dark-red",
-                         "index": 2,
-                         "value": 7000000000
-                      }
-                   ],
-                   "values": false
-                }
-             },
-             "postfix": "",
-             "postfixFontSize": "50%",
-             "prefix": "",
-             "prefixFontSize": "50%",
-             "rangeMaps": [
-                {
-                   "from": "null",
-                   "text": "N/A",
-                   "to": "null"
-                }
-             ],
-             "span": 12,
-             "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-             },
-             "tableColumn": "",
+             "id": 1,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
-                   "format": "time_series",
-                   "instant": null,
-                   "intervalFactor": 1,
-                   "legendFormat": "",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": "",
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Received",
-             "type": "gauge",
-             "valueFontSize": "80%",
-             "valueMaps": [
-                {
-                   "op": "=",
-                   "text": "N/A",
-                   "value": "null"
-                }
-             ],
-             "valueName": "current"
+             "type": "gauge"
           },
           {
-             "cacheTimeout": null,
-             "colorBackground": false,
-             "colorValue": false,
-             "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-             ],
-             "datasource": "$datasource",
-             "decimals": 0,
-             "format": "time_series",
-             "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "displayName": "$namespace",
+                   "max": 10000000000,
+                   "min": 0,
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "dark-green",
+                            "index": 0,
+                            "value": null
+                         },
+                         {
+                            "color": "dark-yellow",
+                            "index": 1,
+                            "value": 5000000000
+                         },
+                         {
+                            "color": "dark-red",
+                            "index": 2,
+                            "value": 7000000000
+                         }
+                      ]
+                   },
+                   "unit": "Bps"
+                }
              },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 1
+                "y": 0
              },
-             "height": 9,
-             "id": 4,
-             "interval": null,
-             "links": [ ],
-             "mappingType": 1,
-             "mappingTypes": [
-                {
-                   "name": "value to text",
-                   "value": 1
-                },
-                {
-                   "name": "range to text",
-                   "value": 2
-                }
-             ],
-             "maxDataPoints": 100,
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "nullText": null,
-             "options": {
-                "fieldOptions": {
-                   "calcs": [
-                      "last"
-                   ],
-                   "defaults": {
-                      "max": 10000000000,
-                      "min": 0,
-                      "title": "$namespace",
-                      "unit": "Bps"
-                   },
-                   "mappings": [ ],
-                   "override": { },
-                   "thresholds": [
-                      {
-                         "color": "dark-green",
-                         "index": 0,
-                         "value": null
-                      },
-                      {
-                         "color": "dark-yellow",
-                         "index": 1,
-                         "value": 5000000000
-                      },
-                      {
-                         "color": "dark-red",
-                         "index": 2,
-                         "value": 7000000000
-                      }
-                   ],
-                   "values": false
-                }
-             },
-             "postfix": "",
-             "postfixFontSize": "50%",
-             "prefix": "",
-             "prefixFontSize": "50%",
-             "rangeMaps": [
-                {
-                   "from": "null",
-                   "text": "N/A",
-                   "to": "null"
-                }
-             ],
-             "span": 12,
-             "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-             },
-             "tableColumn": "",
+             "id": 2,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
-                   "format": "time_series",
-                   "instant": null,
-                   "intervalFactor": 1,
-                   "legendFormat": "",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": "",
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Transmitted",
-             "type": "gauge",
-             "valueFontSize": "80%",
-             "valueMaps": [
-                {
-                   "op": "=",
-                   "text": "N/A",
-                   "value": "null"
-                }
-             ],
-             "valueName": "current"
+             "type": "gauge"
           },
           {
-             "columns": [
-                {
-                   "text": "Time",
-                   "value": "Time"
-                },
-                {
-                   "text": "Value #A",
-                   "value": "Value #A"
-                },
-                {
-                   "text": "Value #B",
-                   "value": "Value #B"
-                },
-                {
-                   "text": "Value #C",
-                   "value": "Value #C"
-                },
-                {
-                   "text": "Value #D",
-                   "value": "Value #D"
-                },
-                {
-                   "text": "Value #E",
-                   "value": "Value #E"
-                },
-                {
-                   "text": "Value #F",
-                   "value": "Value #F"
-                },
-                {
-                   "text": "pod",
-                   "value": "pod"
-                }
-             ],
-             "datasource": "$datasource",
-             "fill": 1,
-             "fontSize": "100%",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bandwidth/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "Bps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Pod"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down",
+                                  "url": "/d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-pod=${__data.fields.Pod}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
              "gridPos": {
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 9
              },
-             "id": 5,
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null as zero",
-             "renderer": "flot",
-             "scroll": true,
-             "showHeader": true,
-             "sort": {
-                "col": 0,
-                "desc": false
-             },
-             "spaceLength": 10,
-             "span": 24,
-             "styles": [
-                {
-                   "alias": "Time",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Time",
-                   "thresholds": [ ],
-                   "type": "hidden",
-                   "unit": "short"
-                },
-                {
-                   "alias": "Bandwidth Received",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #A",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Bandwidth Transmitted",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #B",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Rate of Received Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #C",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #D",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Received Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #E",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #F",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Pod",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": true,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell",
-                   "pattern": "pod",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "short"
-                }
-             ],
+             "id": 3,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "A",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "B",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "C",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "D",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "E",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "F",
-                   "step": 10
+                   "instant": true
                 }
              ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Current Status",
+             "title": "Current Network Usage",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "pod",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Value #A": 7,
+                         "Value #B": 8,
+                         "Value #C": 9,
+                         "Value #D": 10,
+                         "Value #E": 11,
+                         "Value #F": 12,
+                         "pod": 6
+                      },
+                      "renameByName": {
+                         "Value #A": "Current Receive Bandwidth",
+                         "Value #B": "Current Transmit Bandwidth",
+                         "Value #C": "Rate of Received Packets",
+                         "Value #D": "Rate of Transmitted Packets",
+                         "Value #E": "Rate of Received Packets Dropped",
+                         "Value #F": "Rate of Transmitted Packets Dropped",
+                         "pod": "Pod"
+                      }
+                   }
+                }
+             ],
              "type": "table"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 19
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 6,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 20
+                "y": 18
              },
-             "id": 7,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Receive Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 20
+                "y": 18
              },
-             "id": 8,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Transmit Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 29
+                "y": 27
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 27
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 36
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 36
              },
              "id": 9,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 0,
-                      "y": 30
-                   },
-                   "id": 10,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 12,
-                      "y": 30
-                   },
-                   "id": 11,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                "tooltip": {
+                   "mode": "single"
                 }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Packets",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 30
              },
-             "id": 12,
-             "panels": [
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 0,
-                      "y": 40
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 13,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 12,
-                      "y": 40
-                   },
-                   "id": 14,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Errors",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 18,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1143,141 +567,49 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              },
              {
                 "allValue": ".+",
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
+                   "selected": false,
                    "text": "kube-system",
                    "value": "kube-system"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "resolution",
-                "options": [
-                   {
-                      "selected": false,
-                      "text": "30s",
-                      "value": "30s"
-                   },
-                   {
-                      "selected": true,
-                      "text": "5m",
-                      "value": "5m"
-                   },
-                   {
-                      "selected": false,
-                      "text": "1h",
-                      "value": "1h"
-                   }
-                ],
-                "query": "30s,5m,1h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "interval",
-                "options": [
-                   {
-                      "selected": true,
-                      "text": "4h",
-                      "value": "4h"
-                   }
-                ],
-                "query": "4h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1285,33 +617,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Networking / Namespace (Pods)",
-       "uid": "8b7a8b326d7a6f1f04244066368c67af",
-       "version": 0
+       "uid": "8b7a8b326d7a6f1f04244066368c67af"
     }

--- a/resources/grafana/mixins/kubernetes/namespace-by-workload.yaml
+++ b/resources/grafana/mixins/kubernetes/namespace-by-workload.yaml
@@ -9,1345 +9,703 @@ spec:
   name: kubernetes-mixin-namespace-by-workload.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [
-             {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-             }
-          ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
+       "editable": false,
        "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Current Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
-             "gridPos": {
-                "h": 9,
-                "w": 12,
-                "x": 0,
-                "y": 1
+             "id": 1,
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
              },
-             "id": 3,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
-             },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{ workload }}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Received",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "bargauge"
           },
           {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 1
+                "y": 0
              },
-             "id": 4,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+             "id": 2,
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
              },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{ workload }}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Transmitted",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "bargauge"
           },
           {
-             "columns": [
-                {
-                   "text": "Time",
-                   "value": "Time"
-                },
-                {
-                   "text": "Value #A",
-                   "value": "Value #A"
-                },
-                {
-                   "text": "Value #B",
-                   "value": "Value #B"
-                },
-                {
-                   "text": "Value #C",
-                   "value": "Value #C"
-                },
-                {
-                   "text": "Value #D",
-                   "value": "Value #D"
-                },
-                {
-                   "text": "Value #E",
-                   "value": "Value #E"
-                },
-                {
-                   "text": "Value #F",
-                   "value": "Value #F"
-                },
-                {
-                   "text": "Value #G",
-                   "value": "Value #G"
-                },
-                {
-                   "text": "Value #H",
-                   "value": "Value #H"
-                },
-                {
-                   "text": "workload",
-                   "value": "workload"
-                }
-             ],
-             "datasource": "$datasource",
-             "fill": 1,
-             "fontSize": "90%",
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "overrides": [
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Bytes/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "binBps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byRegexp",
+                         "options": "/Packets/"
+                      },
+                      "properties": [
+                         {
+                            "id": "unit",
+                            "value": "pps"
+                         }
+                      ]
+                   },
+                   {
+                      "matcher": {
+                         "id": "byName",
+                         "options": "Workload"
+                      },
+                      "properties": [
+                         {
+                            "id": "links",
+                            "value": [
+                               {
+                                  "title": "Drill down",
+                                  "url": "/d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                               }
+                            ]
+                         }
+                      ]
+                   }
+                ]
+             },
              "gridPos": {
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 10
+                "y": 9
              },
-             "id": 5,
-             "lines": true,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null as zero",
-             "renderer": "flot",
-             "scroll": true,
-             "showHeader": true,
-             "sort": {
-                "col": 0,
-                "desc": false
-             },
-             "spaceLength": 10,
-             "span": 24,
-             "styles": [
-                {
-                   "alias": "Time",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Time",
-                   "thresholds": [ ],
-                   "type": "hidden",
-                   "unit": "short"
-                },
-                {
-                   "alias": "Current Bandwidth Received",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #A",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Current Bandwidth Transmitted",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #B",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Average Bandwidth Received",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #C",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Average Bandwidth Transmitted",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #D",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "Bps"
-                },
-                {
-                   "alias": "Rate of Received Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #E",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #F",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Received Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #G",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Rate of Transmitted Packets Dropped",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": false,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "",
-                   "pattern": "Value #H",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "pps"
-                },
-                {
-                   "alias": "Workload",
-                   "colorMode": null,
-                   "colors": [ ],
-                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                   "decimals": 2,
-                   "link": true,
-                   "linkTooltip": "Drill down",
-                   "linkUrl": "d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell",
-                   "pattern": "workload",
-                   "thresholds": [ ],
-                   "type": "number",
-                   "unit": "short"
-                }
-             ],
+             "id": 3,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "A",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "B",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "C",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "D",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "E",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "F",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "G",
-                   "step": 10
+                   "instant": true
                 },
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                    "format": "table",
-                   "instant": true,
-                   "intervalFactor": 2,
-                   "legendFormat": "",
-                   "refId": "H",
-                   "step": 10
+                   "instant": true
                 }
              ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Status",
+             "transformations": [
+                {
+                   "id": "joinByField",
+                   "options": {
+                      "byField": "workload",
+                      "mode": "outer"
+                   }
+                },
+                {
+                   "id": "organize",
+                   "options": {
+                      "excludeByName": {
+                         "Time": true,
+                         "Time 1": true,
+                         "Time 2": true,
+                         "Time 3": true,
+                         "Time 4": true,
+                         "Time 5": true,
+                         "Time 6": true,
+                         "Time 7": true,
+                         "Time 8": true,
+                         "workload_type 2": true,
+                         "workload_type 3": true,
+                         "workload_type 4": true,
+                         "workload_type 5": true,
+                         "workload_type 6": true,
+                         "workload_type 7": true,
+                         "workload_type 8": true
+                      },
+                      "indexByName": {
+                         "Time 1": 0,
+                         "Time 2": 1,
+                         "Time 3": 2,
+                         "Time 4": 3,
+                         "Time 5": 4,
+                         "Time 6": 5,
+                         "Time 7": 6,
+                         "Time 8": 7,
+                         "Value #A": 10,
+                         "Value #B": 11,
+                         "Value #C": 12,
+                         "Value #D": 13,
+                         "Value #E": 14,
+                         "Value #F": 15,
+                         "Value #G": 16,
+                         "Value #H": 17,
+                         "workload": 8,
+                         "workload_type 1": 9,
+                         "workload_type 2": 18,
+                         "workload_type 3": 19,
+                         "workload_type 4": 20,
+                         "workload_type 5": 21,
+                         "workload_type 6": 22,
+                         "workload_type 7": 23,
+                         "workload_type 8": 24
+                      },
+                      "renameByName": {
+                         "Value #A": "Rx Bytes",
+                         "Value #B": "Tx Bytes",
+                         "Value #C": "Rx Bytes (Avg)",
+                         "Value #D": "Tx Bytes (Avg)",
+                         "Value #E": "Rx Packets",
+                         "Value #F": "Tx Packets",
+                         "Value #G": "Rx Packets Dropped",
+                         "Value #H": "Tx Packets Dropped",
+                         "workload": "Workload",
+                         "workload_type 1": "Type"
+                      }
+                   }
+                }
+             ],
              "type": "table"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 19
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 6,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 20
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "id": 7,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{ workload }}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Received",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 20
-                   },
-                   "id": 8,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{ workload }}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Transmitted",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "unit": "Bps"
                 }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 29
              },
-             "id": 9,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth HIstory",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 38
+                "y": 18
              },
-             "id": 10,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{workload}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Receive Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 38
+                "y": 18
              },
-             "id": 11,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{workload}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Transmit Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 39
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 12,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 40
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "id": 13,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{workload}}",
-                         "refId": "A",
-                         "step": 10
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 27
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 40
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 14,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{workload}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Packets",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Average Container Bandwidth by Workload: Received",
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 40
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 15,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 41
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "id": 16,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{workload}}",
-                         "refId": "A",
-                         "step": 10
-                      }
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 27
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 41
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 17,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{workload}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Errors",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Average Container Bandwidth by Workload: Transmitted",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 36
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 36
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 45
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 45
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 18,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1355,169 +713,61 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              },
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
+                   "selected": false,
                    "text": "kube-system",
                    "value": "kube-system"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "deployment",
-                   "value": "deployment"
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "includeAll": true,
+                "label": "workload_type",
                 "name": "type",
-                "options": [ ],
-                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "resolution",
-                "options": [
-                   {
-                      "selected": false,
-                      "text": "30s",
-                      "value": "30s"
-                   },
-                   {
-                      "selected": true,
-                      "text": "5m",
-                      "value": "5m"
-                   },
-                   {
-                      "selected": false,
-                      "text": "1h",
-                      "value": "1h"
-                   }
-                ],
-                "query": "30s,5m,1h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "interval",
-                "options": [
-                   {
-                      "selected": true,
-                      "text": "4h",
-                      "value": "4h"
-                   }
-                ],
-                "query": "4h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1525,33 +775,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Networking / Namespace (Workload)",
-       "uid": "bbb2a765a623ae38130206c7d94a160f",
-       "version": 0
+       "uid": "bbb2a765a623ae38130206c7d94a160f"
     }

--- a/resources/grafana/mixins/kubernetes/persistentvolumesusage.yaml
+++ b/resources/grafana/mixins/kubernetes/persistentvolumesusage.yaml
@@ -9,394 +9,235 @@ spec:
   name: kubernetes-mixin-persistentvolumesusage.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 9,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "Used Space",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "Free Space",
-                         "refId": "B"
-                      }
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 18,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Volume Space Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
+                   "legendFormat": "Used Space"
                 },
                 {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "rgba(50, 172, 45, 0.97)",
-                      "rgba(237, 129, 40, 0.89)",
-                      "rgba(245, 54, 54, 0.9)"
-                   ],
-                   "datasource": "$datasource",
-                   "format": "percent",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": true,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "gridPos": { },
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 3,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "max without(instance,node) (\n(\n  topk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  topk(1, kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n/\ntopk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "80, 90",
-                   "title": "Volume Space Usage",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "current"
+                   "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
+                   "legendFormat": "Free Space"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Volume Space Usage",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "mode": "thresholds"
+                   },
+                   "max": 100,
+                   "min": 0,
+                   "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         },
+                         {
+                            "color": "orange",
+                            "value": 80
+                         },
+                         {
+                            "color": "red",
+                            "value": 90
+                         }
+                      ]
+                   },
+                   "unit": "percent"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": true,
-                      "current": true,
-                      "max": true,
-                      "min": true,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 9,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "Used inodes",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": " Free inodes",
-                         "refId": "B"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Volume inodes Usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "none",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "none",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "rgba(50, 172, 45, 0.97)",
-                      "rgba(237, 129, 40, 0.89)",
-                      "rgba(245, 54, 54, 0.9)"
-                   ],
-                   "datasource": "$datasource",
-                   "format": "percent",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": true,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
-                   },
-                   "gridPos": { },
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 3,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "max without(instance,node) (\ntopk(1, kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n/\ntopk(1, kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "80, 90",
-                   "title": "Volume inodes Usage",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "current"
+                   "expr": "max without(instance,node) (\n(\n  topk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  topk(1, kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n/\ntopk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Volume Space Usage",
+             "type": "gauge"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "none"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 18,
+                "y": 7
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))",
+                   "legendFormat": "Used inodes"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
+                   "legendFormat": "Free inodes"
+                }
+             ],
+             "title": "Volume inodes Usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "mode": "thresholds"
+                   },
+                   "max": 100,
+                   "min": 0,
+                   "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                         {
+                            "color": "green",
+                            "value": 0
+                         },
+                         {
+                            "color": "orange",
+                            "value": 80
+                         },
+                         {
+                            "color": "red",
+                            "value": 90
+                         }
+                      ]
+                   },
+                   "unit": "percent"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 7
+             },
+             "id": 4,
+             "interval": "1m",
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "max without(instance,node) (\ntopk(1, kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n/\ntopk(1, kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
+                   "instant": true
+                }
+             ],
+             "title": "Volume inodes Usage",
+             "type": "gauge"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -404,111 +245,63 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
-                "includeAll": false,
                 "label": "Namespace",
-                "multi": false,
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
-                "includeAll": false,
                 "label": "PersistentVolumeClaim",
-                "multi": false,
                 "name": "volume",
-                "options": [ ],
                 "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\"}, persistentvolumeclaim)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
        "time": {
-          "from": "now-7d",
+          "from": "now-1h",
           "to": "now"
-       },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
        },
        "timezone": "UTC",
        "title": "Kubernetes / Persistent Volumes",
-       "uid": "919b92a8e8041bd567af9edab12c840c",
-       "version": 0
+       "uid": "919b92a8e8041bd567af9edab12c840c"
     }

--- a/resources/grafana/mixins/kubernetes/pod-total.yaml
+++ b/resources/grafana/mixins/kubernetes/pod-total.yaml
@@ -9,899 +9,393 @@ spec:
   name: kubernetes-mixin-pod-total.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [
-             {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-             }
-          ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
+       "editable": false,
        "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "displayName": "$pod",
+                   "max": 10000000000,
+                   "min": 0,
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "dark-green",
+                            "index": 0,
+                            "value": null
+                         },
+                         {
+                            "color": "dark-yellow",
+                            "index": 1,
+                            "value": 5000000000
+                         },
+                         {
+                            "color": "dark-red",
+                            "index": 2,
+                            "value": 7000000000
+                         }
+                      ]
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Current Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "cacheTimeout": null,
-             "colorBackground": false,
-             "colorValue": false,
-             "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-             ],
-             "datasource": "$datasource",
-             "decimals": 0,
-             "format": "time_series",
-             "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
-             },
-             "gridPos": {
-                "h": 9,
-                "w": 12,
-                "x": 0,
-                "y": 1
-             },
-             "height": 9,
-             "id": 3,
-             "interval": null,
-             "links": [ ],
-             "mappingType": 1,
-             "mappingTypes": [
-                {
-                   "name": "value to text",
-                   "value": 1
-                },
-                {
-                   "name": "range to text",
-                   "value": 2
-                }
-             ],
-             "maxDataPoints": 100,
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "nullText": null,
-             "options": {
-                "fieldOptions": {
-                   "calcs": [
-                      "last"
-                   ],
-                   "defaults": {
-                      "max": 10000000000,
-                      "min": 0,
-                      "title": "$namespace: $pod",
-                      "unit": "Bps"
-                   },
-                   "mappings": [ ],
-                   "override": { },
-                   "thresholds": [
-                      {
-                         "color": "dark-green",
-                         "index": 0,
-                         "value": null
-                      },
-                      {
-                         "color": "dark-yellow",
-                         "index": 1,
-                         "value": 5000000000
-                      },
-                      {
-                         "color": "dark-red",
-                         "index": 2,
-                         "value": 7000000000
-                      }
-                   ],
-                   "values": false
-                }
-             },
-             "postfix": "",
-             "postfixFontSize": "50%",
-             "prefix": "",
-             "prefixFontSize": "50%",
-             "rangeMaps": [
-                {
-                   "from": "null",
-                   "text": "N/A",
-                   "to": "null"
-                }
-             ],
-             "span": 12,
-             "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-             },
-             "tableColumn": "",
+             "id": 1,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
-                   "format": "time_series",
-                   "instant": null,
-                   "intervalFactor": 1,
-                   "legendFormat": "",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": "",
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Received",
-             "type": "gauge",
-             "valueFontSize": "80%",
-             "valueMaps": [
-                {
-                   "op": "=",
-                   "text": "N/A",
-                   "value": "null"
-                }
-             ],
-             "valueName": "current"
+             "type": "gauge"
           },
           {
-             "cacheTimeout": null,
-             "colorBackground": false,
-             "colorValue": false,
-             "colors": [
-                "#299c46",
-                "rgba(237, 129, 40, 0.89)",
-                "#d44a3a"
-             ],
-             "datasource": "$datasource",
-             "decimals": 0,
-             "format": "time_series",
-             "gauge": {
-                "maxValue": 100,
-                "minValue": 0,
-                "show": false,
-                "thresholdLabels": false,
-                "thresholdMarkers": true
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "displayName": "$pod",
+                   "max": 10000000000,
+                   "min": 0,
+                   "thresholds": {
+                      "steps": [
+                         {
+                            "color": "dark-green",
+                            "index": 0,
+                            "value": null
+                         },
+                         {
+                            "color": "dark-yellow",
+                            "index": 1,
+                            "value": 5000000000
+                         },
+                         {
+                            "color": "dark-red",
+                            "index": 2,
+                            "value": 7000000000
+                         }
+                      ]
+                   },
+                   "unit": "Bps"
+                }
              },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 1
+                "y": 0
              },
-             "height": 9,
-             "id": 4,
-             "interval": null,
-             "links": [ ],
-             "mappingType": 1,
-             "mappingTypes": [
-                {
-                   "name": "value to text",
-                   "value": 1
-                },
-                {
-                   "name": "range to text",
-                   "value": 2
-                }
-             ],
-             "maxDataPoints": 100,
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "nullText": null,
-             "options": {
-                "fieldOptions": {
-                   "calcs": [
-                      "last"
-                   ],
-                   "defaults": {
-                      "max": 10000000000,
-                      "min": 0,
-                      "title": "$namespace: $pod",
-                      "unit": "Bps"
-                   },
-                   "mappings": [ ],
-                   "override": { },
-                   "thresholds": [
-                      {
-                         "color": "dark-green",
-                         "index": 0,
-                         "value": null
-                      },
-                      {
-                         "color": "dark-yellow",
-                         "index": 1,
-                         "value": 5000000000
-                      },
-                      {
-                         "color": "dark-red",
-                         "index": 2,
-                         "value": 7000000000
-                      }
-                   ],
-                   "values": false
-                }
-             },
-             "postfix": "",
-             "postfixFontSize": "50%",
-             "prefix": "",
-             "prefixFontSize": "50%",
-             "rangeMaps": [
-                {
-                   "from": "null",
-                   "text": "N/A",
-                   "to": "null"
-                }
-             ],
-             "span": 12,
-             "sparkline": {
-                "fillColor": "rgba(31, 118, 189, 0.18)",
-                "full": false,
-                "lineColor": "rgb(31, 120, 193)",
-                "show": false
-             },
-             "tableColumn": "",
+             "id": 2,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
-                   "format": "time_series",
-                   "instant": null,
-                   "intervalFactor": 1,
-                   "legendFormat": "",
-                   "refId": "A"
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": "",
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Current Rate of Bytes Transmitted",
-             "type": "gauge",
-             "valueFontSize": "80%",
-             "valueMaps": [
-                {
-                   "op": "=",
-                   "text": "N/A",
-                   "value": "null"
-                }
-             ],
-             "valueName": "current"
+             "type": "gauge"
           },
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 10
+                "y": 9
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Receive Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "binBps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 9
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Transmit Bandwidth",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 18
              },
              "id": 5,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
-             "gridPos": {
-                "h": 9,
-                "w": 12,
-                "x": 0,
-                "y": 11
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "id": 6,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
-             },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Receive Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 11
+                "y": 18
              },
-             "id": 7,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Transmit Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
-                "y": 20
+                "y": 27
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "showPoints": "never"
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 27
              },
              "id": 8,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 0,
-                      "y": 21
-                   },
-                   "id": 9,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 12,
-                      "y": 21
-                   },
-                   "id": 10,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                "tooltip": {
+                   "mode": "single"
                 }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Packets",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 21
              },
-             "id": 11,
-             "panels": [
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 0,
-                      "y": 32
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 12,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 10,
-                      "w": 12,
-                      "x": 12,
-                      "y": 32
-                   },
-                   "id": 13,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Errors",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 18,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -909,169 +403,67 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              },
              {
                 "allValue": ".+",
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
+                   "selected": false,
                    "text": "kube-system",
                    "value": "kube-system"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
                 "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": ".+",
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
-                   "text": "",
-                   "value": ""
+                   "selected": false,
+                   "text": "kube-system",
+                   "value": "kube-system"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "pod",
                 "name": "pod",
-                "options": [ ],
                 "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "resolution",
-                "options": [
-                   {
-                      "selected": false,
-                      "text": "30s",
-                      "value": "30s"
-                   },
-                   {
-                      "selected": true,
-                      "text": "5m",
-                      "value": "5m"
-                   },
-                   {
-                      "selected": false,
-                      "text": "1h",
-                      "value": "1h"
-                   }
-                ],
-                "query": "30s,5m,1h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "interval",
-                "options": [
-                   {
-                      "selected": true,
-                      "text": "4h",
-                      "value": "4h"
-                   }
-                ],
-                "query": "4h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1079,33 +471,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Networking / Pod",
-       "uid": "7a18067ce943a40ae25454675c19ff5c",
-       "version": 0
+       "uid": "7a18067ce943a40ae25454675c19ff5c"
     }

--- a/resources/grafana/mixins/kubernetes/proxy.yaml
+++ b/resources/grafana/mixins/kubernetes/proxy.yaml
@@ -9,1012 +9,580 @@ spec:
   name: kubernetes-mixin-proxy.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "none"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 4,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "format": "none",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "gridPos": { },
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 2,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "sum(up{cluster=\"$cluster\", job=\"machine-config-daemon\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Up",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "min"
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 5,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "rate",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rules Sync Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 5,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rule Sync Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(up{cluster=\"$cluster\", job=\"machine-config-daemon\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Up",
+             "type": "stat"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "rate",
-                         "refId": "A"
-                      }
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 4,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Network Programming Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 6,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m])) by (instance, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Network Programming Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+                   "legendFormat": "rate"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rules Sync Rate",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "2xx",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "3xx",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "4xx",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "5xx",
-                         "refId": "D"
-                      }
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 14,
+                "y": 0
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Kube API Request Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 8,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\",verb=\"POST\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Post Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rules Sync Latency 99th Quantile",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 0,
+                "y": 7
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Get Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+                   "legendFormat": "rate"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Network Programming Rate",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 12,
+                "x": 12,
+                "y": 7
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 11,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}[5m])",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 12,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Goroutines",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m])) by (instance, le))",
+                   "legendFormat": "{{instance}}"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Network Programming Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 14
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                   "legendFormat": "2xx"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                   "legendFormat": "3xx"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                   "legendFormat": "4xx"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                   "legendFormat": "5xx"
+                }
+             ],
+             "title": "Kube API Request Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 16,
+                "x": 8,
+                "y": 14
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\",verb=\"POST\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Post Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Get Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 28
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Memory",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 28
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}[5m])",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "CPU usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 28
+             },
+             "id": 11,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "go_goroutines{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Goroutines",
+             "type": "timeseries"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1022,57 +590,43 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"machine-config-daemon\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "allValue": ".+",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "instance",
                 "name": "instance",
-                "options": [ ],
                 "query": "label_values(up{job=\"machine-config-daemon\", cluster=\"$cluster\", job=\"machine-config-daemon\"}, instance)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1080,33 +634,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Proxy",
-       "uid": "632e265de029684c40b21cb76bca4f94",
-       "version": 0
+       "uid": "632e265de029684c40b21cb76bca4f94"
     }

--- a/resources/grafana/mixins/kubernetes/scheduler.yaml
+++ b/resources/grafana/mixins/kubernetes/scheduler.yaml
@@ -9,877 +9,526 @@ spec:
   name: kubernetes-mixin-scheduler.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [ ]
-       },
        "editable": false,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
-       "refresh": "10s",
-       "rows": [
+       "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "unit": "none"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 4,
+                "x": 0,
+                "y": 0
+             },
+             "id": 1,
+             "interval": "1m",
+             "options": {
+                "colorMode": "none"
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "cacheTimeout": null,
-                   "colorBackground": false,
-                   "colorValue": false,
-                   "colors": [
-                      "#299c46",
-                      "rgba(237, 129, 40, 0.89)",
-                      "#d44a3a"
-                   ],
-                   "datasource": "$datasource",
-                   "format": "none",
-                   "gauge": {
-                      "maxValue": 100,
-                      "minValue": 0,
-                      "show": false,
-                      "thresholdLabels": false,
-                      "thresholdMarkers": true
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "gridPos": { },
-                   "id": 2,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "rightSide": true
-                   },
-                   "links": [ ],
-                   "mappingType": 1,
-                   "mappingTypes": [
-                      {
-                         "name": "value to text",
-                         "value": 1
-                      },
-                      {
-                         "name": "range to text",
-                         "value": 2
-                      }
-                   ],
-                   "maxDataPoints": 100,
-                   "nullPointMode": "connected",
-                   "nullText": null,
-                   "postfix": "",
-                   "postfixFontSize": "50%",
-                   "prefix": "",
-                   "prefixFontSize": "50%",
-                   "rangeMaps": [
-                      {
-                         "from": "null",
-                         "text": "N/A",
-                         "to": "null"
-                      }
-                   ],
-                   "span": 2,
-                   "sparkline": {
-                      "fillColor": "rgba(31, 118, 189, 0.18)",
-                      "full": false,
-                      "lineColor": "rgb(31, 120, 193)",
-                      "show": false
-                   },
-                   "tableColumn": "",
-                   "targets": [
-                      {
-                         "expr": "sum(up{cluster=\"$cluster\", job=\"scheduler\"})",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": "",
-                   "title": "Up",
-                   "tooltip": {
-                      "shared": false
-                   },
-                   "type": "singlestat",
-                   "valueFontSize": "80%",
-                   "valueMaps": [
-                      {
-                         "op": "=",
-                         "text": "N/A",
-                         "value": "null"
-                      }
-                   ],
-                   "valueName": "min"
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 3,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 5,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} e2e",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} binding",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} volume",
-                         "refId": "D"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Scheduling Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 4,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 5,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} e2e",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} binding",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{cluster}} {{instance}} volume",
-                         "refId": "D"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Scheduling latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(up{cluster=\"$cluster\", job=\"scheduler\"})",
+                   "instant": true
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Up",
+             "type": "stat"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 5,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "2xx",
-                         "refId": "A"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "3xx",
-                         "refId": "B"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "4xx",
-                         "refId": "C"
-                      },
-                      {
-                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "5xx",
-                         "refId": "D"
-                      }
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 4,
+                "y": 0
+             },
+             "id": 2,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Kube API Request Rate",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "ops",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+                   "legendFormat": "{{cluster}} {{instance}} e2e"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 6,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 8,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Post Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+                   "legendFormat": "{{cluster}} {{instance}} binding"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+                   "legendFormat": "{{cluster}} {{instance}} scheduling algorithm"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+                   "legendFormat": "{{cluster}} {{instance}} volume"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Scheduling Rate",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 7,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": true
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{verb}} {{url}}",
-                         "refId": "A"
-                      }
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 10,
+                "x": 14,
+                "y": 0
+             },
+             "id": 3,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Get Request Latency 99th Quantile",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
+                   "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+                   "legendFormat": "{{cluster}} {{instance}} e2e"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "yaxes": [
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "s",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+                   "legendFormat": "{{cluster}} {{instance}} binding"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+                   "legendFormat": "{{cluster}} {{instance}} scheduling algorithm"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+                   "legendFormat": "{{cluster}} {{instance}} volume"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Scheduling latency 99th Quantile",
+             "type": "timeseries"
           },
           {
-             "collapse": false,
-             "collapsed": false,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 8,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 7
+             },
+             "id": 4,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Memory",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                   "legendFormat": "2xx"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 9,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "CPU usage",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "bytes",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                   "legendFormat": "3xx"
                 },
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 1,
-                   "fillGradient": 0,
-                   "gridPos": { },
-                   "id": 10,
-                   "interval": "1m",
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": false,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "lines": true,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "nullPointMode": "null",
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 4,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}",
-                         "format": "time_series",
-                         "intervalFactor": 2,
-                         "legendFormat": "{{instance}}",
-                         "refId": "A"
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Goroutines",
-                   "tooltip": {
-                      "shared": false,
-                      "sort": 0,
-                      "value_type": "individual"
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                   "legendFormat": "4xx"
+                },
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      },
-                      {
-                         "format": "short",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": null,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                   "legendFormat": "5xx"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": false,
-             "title": "Dashboard Row",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Kube API Request Rate",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "ops"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 16,
+                "x": 8,
+                "y": 7
+             },
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Post Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "s"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 14
+             },
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                   "legendFormat": "{{verb}} {{url}}"
+                }
+             ],
+             "title": "Get Request Latency 99th Quantile",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "bytes"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 0,
+                "y": 21
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Memory",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 8,
+                "y": 21
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "CPU usage",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "short"
+                }
+             },
+             "gridPos": {
+                "h": 7,
+                "w": 8,
+                "x": 16,
+                "y": 21
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "go_goroutines{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}",
+                   "legendFormat": "{{instance}}"
+                }
+             ],
+             "title": "Goroutines",
+             "type": "timeseries"
           }
        ],
-       "schemaVersion": 14,
-       "style": "dark",
+       "refresh": "10s",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -887,57 +536,43 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
                 "label": "cluster",
-                "multi": false,
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(up{job=\"scheduler\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "allValue": ".+",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "instance",
                 "name": "instance",
-                "options": [ ],
                 "query": "label_values(up{job=\"scheduler\", cluster=\"$cluster\"}, instance)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -945,33 +580,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Scheduler",
-       "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
-       "version": 0
+       "uid": "2e6b6a3b4bddf1427b3a55aa1311c656"
     }

--- a/resources/grafana/mixins/kubernetes/workload-total.yaml
+++ b/resources/grafana/mixins/kubernetes/workload-total.yaml
@@ -9,1057 +9,473 @@ spec:
   name: kubernetes-mixin-workload-total.json
   json: |
     {
-       "__inputs": [ ],
-       "__requires": [ ],
-       "annotations": {
-          "list": [
-             {
-                "builtIn": 1,
-                "datasource": "-- Grafana --",
-                "enable": true,
-                "hide": true,
-                "iconColor": "rgba(0, 211, 255, 1)",
-                "name": "Annotations & Alerts",
-                "type": "dashboard"
-             }
-          ]
-       },
-       "editable": true,
-       "gnetId": null,
-       "graphTooltip": 0,
-       "hideControls": false,
-       "id": null,
-       "links": [ ],
+       "editable": false,
        "panels": [
           {
-             "collapse": false,
-             "collapsed": false,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
-                "h": 1,
-                "w": 24,
+                "h": 9,
+                "w": 12,
                 "x": 0,
                 "y": 0
              },
-             "id": 2,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Current Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
+             "id": 1,
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Current Rate of Bytes Received",
+             "type": "bargauge"
           },
           {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 0
+             },
+             "id": 2,
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Current Rate of Bytes Transmitted",
+             "type": "bargauge"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 1
+                "y": 9
              },
              "id": 3,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
              },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{ pod }}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Current Rate of Bytes Received",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "title": "Average Rate of Bytes Received",
+             "type": "bargauge"
           },
           {
-             "aliasColors": { },
-             "bars": true,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "color": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                   },
+                   "unit": "Bps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 1
+                "y": 9
              },
              "id": 4,
-             "legend": {
-                "alignAsTable": true,
-                "avg": false,
-                "current": true,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": true,
-                "show": true,
-                "sideWidth": null,
-                "sort": "current",
-                "sortDesc": true,
-                "total": false,
-                "values": true
+             "options": {
+                "displayMode": "basic",
+                "showUnfilled": false
              },
-             "lines": false,
-             "linewidth": 1,
-             "links": [ ],
-             "minSpan": 24,
-             "nullPointMode": "null",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 24,
-             "stack": false,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{ pod }}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
-             "title": "Current Rate of Bytes Transmitted",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
+             "title": "Average Rate of Bytes Transmitted",
+             "type": "bargauge"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "series",
-                "name": null,
-                "show": false,
-                "values": [
-                   "current"
-                ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "binBps"
                 }
-             ]
-          },
-          {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 10
              },
-             "id": 5,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 11
-                   },
-                   "id": 6,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{ pod }}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Received",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                },
-                {
-                   "aliasColors": { },
-                   "bars": true,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 11
-                   },
-                   "id": 7,
-                   "legend": {
-                      "alignAsTable": true,
-                      "avg": false,
-                      "current": true,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": true,
-                      "show": true,
-                      "sideWidth": null,
-                      "sort": "current",
-                      "sortDesc": true,
-                      "total": false,
-                      "values": true
-                   },
-                   "lines": false,
-                   "linewidth": 1,
-                   "links": [ ],
-                   "minSpan": 24,
-                   "nullPointMode": "null",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 24,
-                   "stack": false,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{ pod }}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Average Rate of Bytes Transmitted",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "series",
-                      "name": null,
-                      "show": false,
-                      "values": [
-                         "current"
-                      ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "Bps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
-                }
-             ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Average Bandwidth",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "collapse": false,
-             "collapsed": false,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 11
-             },
-             "id": 8,
-             "panels": [ ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Bandwidth HIstory",
-             "titleSize": "h6",
-             "type": "row"
-          },
-          {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 12
+                "y": 18
              },
-             "id": 9,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 5,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Receive Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "aliasColors": { },
-             "bars": false,
-             "dashLength": 10,
-             "dashes": false,
-             "datasource": "$datasource",
-             "fill": 2,
-             "fillGradient": 0,
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "binBps"
+                }
+             },
              "gridPos": {
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 12
+                "y": 18
              },
-             "id": 10,
-             "legend": {
-                "alignAsTable": false,
-                "avg": false,
-                "current": false,
-                "hideEmpty": true,
-                "hideZero": true,
-                "max": false,
-                "min": false,
-                "rightSide": false,
-                "show": true,
-                "sideWidth": null,
-                "total": false,
-                "values": false
+             "id": 6,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
              },
-             "lines": true,
-             "linewidth": 2,
-             "links": [ ],
-             "minSpan": 12,
-             "nullPointMode": "connected",
-             "paceLength": 10,
-             "percentage": false,
-             "pointradius": 5,
-             "points": false,
-             "renderer": "flot",
-             "repeat": null,
-             "seriesOverrides": [ ],
-             "spaceLength": 10,
-             "span": 12,
-             "stack": true,
-             "steppedLine": false,
+             "pluginVersion": "v11.0.0",
              "targets": [
                 {
-                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                   "format": "time_series",
-                   "intervalFactor": 1,
-                   "legendFormat": "{{pod}}",
-                   "refId": "A",
-                   "step": 10
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "thresholds": [ ],
-             "timeFrom": null,
-             "timeShift": null,
              "title": "Transmit Bandwidth",
-             "tooltip": {
-                "shared": true,
-                "sort": 2,
-                "value_type": "individual"
-             },
-             "type": "graph",
-             "xaxis": {
-                "buckets": null,
-                "mode": "time",
-                "name": null,
-                "show": true,
-                "values": [ ]
-             },
-             "yaxes": [
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                },
-                {
-                   "format": "Bps",
-                   "label": null,
-                   "logBase": 1,
-                   "max": null,
-                   "min": 0,
-                   "show": true
-                }
-             ]
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 21
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 11,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 22
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "id": 12,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 27
+             },
+             "id": 7,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 22
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 13,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Packets",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of Received Packets",
+             "type": "timeseries"
           },
           {
-             "collapse": true,
-             "collapsed": true,
-             "gridPos": {
-                "h": 1,
-                "w": 24,
-                "x": 0,
-                "y": 22
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
              },
-             "id": 14,
-             "panels": [
-                {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 0,
-                      "y": 23
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
                    },
-                   "id": 15,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 27
+             },
+             "id": 8,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
                    ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Received Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
                 },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
                 {
-                   "aliasColors": { },
-                   "bars": false,
-                   "dashLength": 10,
-                   "dashes": false,
-                   "datasource": "$datasource",
-                   "fill": 2,
-                   "fillGradient": 0,
-                   "gridPos": {
-                      "h": 9,
-                      "w": 12,
-                      "x": 12,
-                      "y": 23
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
                    },
-                   "id": 16,
-                   "legend": {
-                      "alignAsTable": false,
-                      "avg": false,
-                      "current": false,
-                      "hideEmpty": true,
-                      "hideZero": true,
-                      "max": false,
-                      "min": false,
-                      "rightSide": false,
-                      "show": true,
-                      "sideWidth": null,
-                      "total": false,
-                      "values": false
-                   },
-                   "lines": true,
-                   "linewidth": 2,
-                   "links": [ ],
-                   "minSpan": 12,
-                   "nullPointMode": "connected",
-                   "paceLength": 10,
-                   "percentage": false,
-                   "pointradius": 5,
-                   "points": false,
-                   "renderer": "flot",
-                   "repeat": null,
-                   "seriesOverrides": [ ],
-                   "spaceLength": 10,
-                   "span": 12,
-                   "stack": true,
-                   "steppedLine": false,
-                   "targets": [
-                      {
-                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                         "format": "time_series",
-                         "intervalFactor": 1,
-                         "legendFormat": "{{pod}}",
-                         "refId": "A",
-                         "step": 10
-                      }
-                   ],
-                   "thresholds": [ ],
-                   "timeFrom": null,
-                   "timeShift": null,
-                   "title": "Rate of Transmitted Packets Dropped",
-                   "tooltip": {
-                      "shared": true,
-                      "sort": 2,
-                      "value_type": "individual"
-                   },
-                   "type": "graph",
-                   "xaxis": {
-                      "buckets": null,
-                      "mode": "time",
-                      "name": null,
-                      "show": true,
-                      "values": [ ]
-                   },
-                   "yaxes": [
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      },
-                      {
-                         "format": "pps",
-                         "label": null,
-                         "logBase": 1,
-                         "max": null,
-                         "min": 0,
-                         "show": true
-                      }
-                   ]
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
                 }
              ],
-             "repeat": null,
-             "repeatIteration": null,
-             "repeatRowId": null,
-             "showTitle": true,
-             "title": "Errors",
-             "titleSize": "h6",
-             "type": "row"
+             "title": "Rate of Transmitted Packets",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 36
+             },
+             "id": 9,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Received Packets Dropped",
+             "type": "timeseries"
+          },
+          {
+             "datasource": {
+                "type": "datasource",
+                "uid": "-- Mixed --"
+             },
+             "fieldConfig": {
+                "defaults": {
+                   "custom": {
+                      "fillOpacity": 10,
+                      "showPoints": "never",
+                      "spanNulls": true
+                   },
+                   "unit": "pps"
+                }
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 36
+             },
+             "id": 10,
+             "interval": "1m",
+             "options": {
+                "legend": {
+                   "asTable": true,
+                   "calcs": [
+                      "lastNotNull"
+                   ],
+                   "displayMode": "table",
+                   "placement": "right",
+                   "showLegend": true
+                },
+                "tooltip": {
+                   "mode": "single"
+                }
+             },
+             "pluginVersion": "v11.0.0",
+             "targets": [
+                {
+                   "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                   },
+                   "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+                   "legendFormat": "__auto"
+                }
+             ],
+             "title": "Rate of Transmitted Packets Dropped",
+             "type": "timeseries"
           }
        ],
        "refresh": "10s",
-       "rows": [ ],
-       "schemaVersion": 18,
-       "style": "dark",
+       "schemaVersion": 39,
        "tags": [
           "kubernetes-mixin"
        ],
@@ -1067,197 +483,77 @@ spec:
           "list": [
              {
                 "current": {
+                   "selected": true,
                    "text": "default",
                    "value": "default"
                 },
                 "hide": 0,
-                "label": "Data Source",
+                "label": "Data source",
                 "name": "datasource",
-                "options": [ ],
                 "query": "prometheus",
-                "refresh": 1,
                 "regex": "",
                 "type": "datasource"
              },
              {
-                "allValue": null,
-                "current": { },
-                "datasource": "$datasource",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "cluster",
                 "name": "cluster",
-                "options": [ ],
                 "query": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster)",
                 "refresh": 2,
-                "regex": "",
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "sort": 1,
+                "type": "query"
              },
              {
                 "allValue": ".+",
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
                 "current": {
+                   "selected": false,
                    "text": "kube-system",
                    "value": "kube-system"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\"}, namespace)",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
+                },
                 "hide": 0,
                 "includeAll": true,
-                "label": null,
-                "multi": false,
+                "label": "namespace",
                 "name": "namespace",
-                "options": [ ],
-                "query": "label_values(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\"}, namespace)",
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "",
-                   "value": ""
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "label": "workload",
                 "name": "workload",
-                "options": [ ],
-                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\"}, workload)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
+                "type": "query"
              },
              {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "deployment",
-                   "value": "deployment"
+                "allValue": ".+",
+                "datasource": {
+                   "type": "prometheus",
+                   "uid": "${datasource}"
                 },
-                "datasource": "$datasource",
-                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
                 "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
+                "includeAll": true,
+                "label": "workload_type",
                 "name": "type",
-                "options": [ ],
-                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
                 "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 0,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "query",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 0,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "resolution",
-                "options": [
-                   {
-                      "selected": false,
-                      "text": "30s",
-                      "value": "30s"
-                   },
-                   {
-                      "selected": true,
-                      "text": "5m",
-                      "value": "5m"
-                   },
-                   {
-                      "selected": false,
-                      "text": "1h",
-                      "value": "1h"
-                   }
-                ],
-                "query": "30s,5m,1h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
                 "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
-             },
-             {
-                "allValue": null,
-                "auto": false,
-                "auto_count": 30,
-                "auto_min": "10s",
-                "current": {
-                   "text": "5m",
-                   "value": "5m"
-                },
-                "datasource": "$datasource",
-                "hide": 2,
-                "includeAll": false,
-                "label": null,
-                "multi": false,
-                "name": "interval",
-                "options": [
-                   {
-                      "selected": true,
-                      "text": "4h",
-                      "value": "4h"
-                   }
-                ],
-                "query": "4h",
-                "refresh": 2,
-                "regex": "",
-                "skipUrlSync": false,
-                "sort": 1,
-                "tagValuesQuery": "",
-                "tags": [ ],
-                "tagsQuery": "",
-                "type": "interval",
-                "useTags": false
+                "type": "query"
              }
           ]
        },
@@ -1265,33 +561,7 @@ spec:
           "from": "now-1h",
           "to": "now"
        },
-       "timepicker": {
-          "refresh_intervals": [
-             "5s",
-             "10s",
-             "30s",
-             "1m",
-             "5m",
-             "15m",
-             "30m",
-             "1h",
-             "2h",
-             "1d"
-          ],
-          "time_options": [
-             "5m",
-             "15m",
-             "1h",
-             "6h",
-             "12h",
-             "24h",
-             "2d",
-             "7d",
-             "30d"
-          ]
-       },
        "timezone": "UTC",
        "title": "Kubernetes / Networking / Workload",
-       "uid": "728bf77cc1166d2f3133bf25846876cc",
-       "version": 0
+       "uid": "728bf77cc1166d2f3133bf25846876cc"
     }

--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -363,9 +363,9 @@
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
       "summary": "Processes experience elevated CPU throttling."
     "expr": |
-      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (cluster, container, pod, namespace)
         /
-      sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
+      sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (cluster, container, pod, namespace)
         > ( 25 / 100 )
     "for": "15m"
     "labels":
@@ -375,7 +375,7 @@
   "rules":
   - "alert": "KubePersistentVolumeFillingUp"
     "annotations":
-      "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+      "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is only {{ $value | humanizePercentage }} free."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup"
       "summary": "PersistentVolume is filling up."
     "expr": |
@@ -386,9 +386,9 @@
       ) < 0.03
       and
       kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
@@ -396,7 +396,7 @@
       "source": "mixin/kubernetes"
   - "alert": "KubePersistentVolumeFillingUp"
     "annotations":
-      "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available."
+      "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup"
       "summary": "PersistentVolume is filling up."
     "expr": |
@@ -409,9 +409,9 @@
       kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
       and
       predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
@@ -419,7 +419,7 @@
       "source": "mixin/kubernetes"
   - "alert": "KubePersistentVolumeInodesFillingUp"
     "annotations":
-      "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} only has {{ $value | humanizePercentage }} free inodes."
+      "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} only has {{ $value | humanizePercentage }} free inodes."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup"
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
@@ -430,9 +430,9 @@
       ) < 0.03
       and
       kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1m"
     "labels":
@@ -440,7 +440,7 @@
       "source": "mixin/kubernetes"
   - "alert": "KubePersistentVolumeInodesFillingUp"
     "annotations":
-      "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free."
+      "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup"
       "summary": "PersistentVolumeInodes are filling up."
     "expr": |
@@ -453,9 +453,9 @@
       kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
       and
       predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-      unless on(namespace, persistentvolumeclaim)
+      unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
     "for": "1h"
     "labels":
@@ -463,7 +463,7 @@
       "source": "mixin/kubernetes"
   - "alert": "KubePersistentVolumeErrors"
     "annotations":
-      "description": "The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}."
+      "description": "The persistent volume {{ $labels.persistentvolume }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} has status {{ $labels.phase }}."
       "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
       "summary": "PersistentVolume is having issues with provisioning."
     "expr": |

--- a/resources/mixins/kubernetes/generated/dashboards/apiserver.json
+++ b/resources/mixins/kubernetes/generated/dashboards/apiserver.json
@@ -1,19 +1,11 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
    "panels": [
       {
-         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
-         "datasource": null,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "description": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
          "gridPos": {
             "h": 2,
@@ -21,1451 +13,794 @@
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "mode": "markdown",
-         "span": 12,
+         "id": 1,
+         "options": {
+            "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
+         },
+         "pluginVersion": "v11.0.0",
          "title": "Notice",
          "type": "text"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 3,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 2
+         },
+         "id": 2,
+         "interval": "1m",
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}"
+            }
+         ],
+         "title": "Availability (30d) > 99.000%",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How much error budget is left looking at our 0.990% availability guarantees?",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 100
+               },
+               "decimals": 3,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 2
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
+               "legendFormat": "errorbudget"
+            }
+         ],
+         "title": "ErrorBudget (30d) > 99.000%",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 3,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 9
+         },
+         "id": 4,
+         "interval": "1m",
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}"
+            }
+         ],
+         "title": "Read Availability (30d)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 100,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "reqps"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/2../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#56A64B"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/3../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#F2CC0C"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/4../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#3274D9"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/5../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#E02F44"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 9
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+               "legendFormat": "{{ code }}"
+            }
+         ],
+         "title": "Read SLI - Requests",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 9
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+               "legendFormat": "{{ resource }}"
+            }
+         ],
+         "title": "Read SLI - Errors",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 9
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
+               "legendFormat": "{{ resource }}"
+            }
+         ],
+         "title": "Read SLI - Duration",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
+         "fieldConfig": {
+            "defaults": {
+               "decimals": 3,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 16
+         },
+         "id": 8,
+         "interval": "1m",
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}"
+            }
+         ],
+         "title": "Write Availability (30d)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 100,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "reqps"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/2../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#56A64B"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/3../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#F2CC0C"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/4../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#3274D9"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/5../i"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": "#E02F44"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 16
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+               "legendFormat": "{{ code }}"
+            }
+         ],
+         "title": "Write SLI - Requests",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 12,
+            "y": 16
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+               "legendFormat": "{{ resource }}"
+            }
+         ],
+         "title": "Write SLI - Errors",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
+         "fieldConfig": {
+            "defaults": {
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 16
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
+               "legendFormat": "{{ resource }}"
+            }
+         ],
+         "title": "Write SLI - Duration",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 23
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": false
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(workqueue_adds_total{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+               "legendFormat": "{{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Add Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 23
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": false
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(workqueue_depth{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+               "legendFormat": "{{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Depth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 30
+         },
+         "id": 14,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
+               "legendFormat": "{{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Latency",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 37
+         },
+         "id": 15,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "process_resident_memory_bytes{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Memory",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "min": 0,
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 37
+         },
+         "id": 16,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "rate(process_cpu_seconds_total{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "CPU usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 37
+         },
+         "id": 17,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "go_goroutines{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Goroutines",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "decimals": 3,
-               "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
-               "format": "percentunit",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
-               },
-               "gridPos": { },
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 4,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Availability (30d) > 99.000%",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "avg"
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "decimals": 3,
-               "description": "How much error budget is left looking at our 0.990% availability guarantees?",
-               "fill": 10,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 8,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "errorbudget",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ErrorBudget (30d) > 99.000%",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "decimals": 3,
-               "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
-               "format": "percentunit",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
-               },
-               "gridPos": { },
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 3,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Read Availability (30d)",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "avg"
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
-               "fill": 10,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [
-                  {
-                     "alias": "/2../i",
-                     "color": "#56A64B"
-                  },
-                  {
-                     "alias": "/3../i",
-                     "color": "#F2CC0C"
-                  },
-                  {
-                     "alias": "/4../i",
-                     "color": "#3274D9"
-                  },
-                  {
-                     "alias": "/5../i",
-                     "color": "#E02F44"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ code }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Read SLI - Requests",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "reqps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "reqps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ resource }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Read SLI - Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ resource }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Read SLI - Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "decimals": 3,
-               "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
-               "format": "percentunit",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
-               },
-               "gridPos": { },
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 3,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Write Availability (30d)",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "avg"
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
-               "fill": 10,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [
-                  {
-                     "alias": "/2../i",
-                     "color": "#56A64B"
-                  },
-                  {
-                     "alias": "/3../i",
-                     "color": "#F2CC0C"
-                  },
-                  {
-                     "alias": "/4../i",
-                     "color": "#3274D9"
-                  },
-                  {
-                     "alias": "/5../i",
-                     "color": "#E02F44"
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ code }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Write SLI - Requests",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "reqps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "reqps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ resource }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Write SLI - Errors",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{ resource }}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Write SLI - Duration",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": false,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(workqueue_adds_total{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Add Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 14,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": false,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(workqueue_depth{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Depth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 15,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"api\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Latency",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 16,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "process_resident_memory_bytes{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 17,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(process_cpu_seconds_total{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 18,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{job=\"api\",instance=~\"$instance\", cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      }
-   ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1473,57 +808,42 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"api\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
             "name": "instance",
-            "options": [ ],
             "query": "label_values(up{job=\"api\", cluster=\"$cluster\"}, instance)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1531,33 +851,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / API server",
-   "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
-   "version": 0
+   "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/cluster-total.json
+++ b/resources/mixins/kubernetes/generated/dashboards/cluster-total.json
@@ -1,1651 +1,781 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [
-         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-         }
-      ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "editable": false,
    "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 0
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 2,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Current Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 0
          },
-         "id": 3,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{namespace}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Received",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 0
          },
-         "id": 4,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{namespace}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Transmitted",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "columns": [
-            {
-               "text": "Time",
-               "value": "Time"
-            },
-            {
-               "text": "Value #A",
-               "value": "Value #A"
-            },
-            {
-               "text": "Value #B",
-               "value": "Value #B"
-            },
-            {
-               "text": "Value #C",
-               "value": "Value #C"
-            },
-            {
-               "text": "Value #D",
-               "value": "Value #D"
-            },
-            {
-               "text": "Value #E",
-               "value": "Value #E"
-            },
-            {
-               "text": "Value #F",
-               "value": "Value #F"
-            },
-            {
-               "text": "Value #G",
-               "value": "Value #G"
-            },
-            {
-               "text": "Value #H",
-               "value": "Value #H"
-            },
-            {
-               "text": "namespace",
-               "value": "namespace"
-            }
-         ],
-         "datasource": "$datasource",
-         "fill": 1,
-         "fontSize": "90%",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bytes/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "binBps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down",
+                              "url": "/d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 10
+            "y": 9
          },
-         "id": 5,
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null as zero",
-         "renderer": "flot",
-         "scroll": true,
-         "showHeader": true,
-         "sort": {
-            "col": 0,
-            "desc": false
-         },
-         "spaceLength": 10,
-         "span": 24,
-         "styles": [
-            {
-               "alias": "Time",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Time",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short"
-            },
-            {
-               "alias": "Current Bandwidth Received",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #A",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Current Bandwidth Transmitted",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #B",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Average Bandwidth Received",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #C",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Average Bandwidth Transmitted",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #D",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Rate of Received Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #E",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #F",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Received Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #G",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #H",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Namespace",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": true,
-               "linkTooltip": "Drill down",
-               "linkUrl": "d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=$__cell",
-               "pattern": "namespace",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "short"
-            }
-         ],
+         "id": 3,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "B",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "C",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "D",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "E",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "F",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "G",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "H",
-               "step": 10
+               "instant": true
             }
          ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Status",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true,
+                     "Time 8": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Time 8": 7,
+                     "Value #A": 9,
+                     "Value #B": 10,
+                     "Value #C": 11,
+                     "Value #D": 12,
+                     "Value #E": 13,
+                     "Value #F": 14,
+                     "Value #G": 15,
+                     "Value #H": 16,
+                     "namespace": 8
+                  },
+                  "renameByName": {
+                     "Value #A": "Rx Bytes",
+                     "Value #B": "Tx Bytes",
+                     "Value #C": "Rx Bytes (Avg)",
+                     "Value #D": "Tx Bytes (Avg)",
+                     "Value #E": "Rx Packets",
+                     "Value #F": "Tx Packets",
+                     "Value #G": "Rx Packets Dropped",
+                     "Value #H": "Tx Packets Dropped",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
          "type": "table"
       },
       {
-         "collapse": true,
-         "collapsed": true,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 10
+            "y": 18
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Rate of Bytes Received",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 18
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Rate of Bytes Transmitted",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 27
          },
          "id": 6,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 11
-               },
-               "id": 7,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Received",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 11
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 8,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Transmitted",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum by (namespace) (rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 27
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 11
+            "y": 36
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 36
          },
          "id": 9,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth History",
-         "titleSize": "h6",
-         "type": "row"
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
          "gridPos": {
             "h": 9,
-            "w": 24,
+            "w": 12,
             "x": 0,
-            "y": 12
+            "y": 45
          },
          "id": 10,
-         "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{namespace}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Receive Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
          "gridPos": {
             "h": 9,
-            "w": 24,
-            "x": 0,
-            "y": 21
+            "w": 12,
+            "x": 12,
+            "y": 45
          },
          "id": 11,
-         "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{namespace}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Transmit Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "percentunit"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 30
+            "y": 54
          },
          "id": 12,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 31
-               },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 40
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 14,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum by (instance) (rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[5m]) / rate(node_netstat_Tcp_OutSegs{cluster=\"$cluster\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Packets",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of TCP Retransmits out of all sent segments",
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 31
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 15,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 50
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
                },
-               "id": 16,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 54
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 59
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 17,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{namespace}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 59
-               },
-               "id": 18,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [
-                  {
-                     "targetBlank": true,
-                     "title": "What is TCP Retransmit?",
-                     "url": "https://accedian.com/enterprises/blog/network-packet-loss-retransmissions-and-duplicate-acknowledgements/"
-                  }
-               ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_OutSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of TCP Retransmits out of all sent segments",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 24,
-                  "x": 0,
-                  "y": 59
-               },
-               "id": 19,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [
-                  {
-                     "targetBlank": true,
-                     "title": "Why monitor SYN retransmits?",
-                     "url": "https://github.com/prometheus/node_exporter/issues/1023#issuecomment-408128365"
-                  }
-               ],
-               "minSpan": 24,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(rate(node_netstat_TcpExt_TCPSynRetrans{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of TCP SYN Retransmits out of all retransmits",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum by (instance) (rate(node_netstat_TcpExt_TCPSynRetrans{cluster=\"$cluster\"}[5m]) / rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Errors",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of TCP SYN Retransmits out of all retransmits",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 18,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
    "templating": {
       "list": [
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "resolution",
-            "options": [
-               {
-                  "selected": false,
-                  "text": "30s",
-                  "value": "30s"
-               },
-               {
-                  "selected": true,
-                  "text": "5m",
-                  "value": "5m"
-               },
-               {
-                  "selected": false,
-                  "text": "1h",
-                  "value": "1h"
-               }
-            ],
-            "query": "30s,5m,1h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "interval",
-            "options": [
-               {
-                  "selected": true,
-                  "text": "4h",
-                  "value": "4h"
-               }
-            ],
-            "query": "4h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
             "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          }
       ]
    },
@@ -1653,33 +783,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Networking / Cluster",
-   "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
-   "version": 0
+   "uid": "ff635a025bcfea7bc3dd4f508990a3e9"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/controller-manager.json
+++ b/resources/mixins/kubernetes/generated/dashboards/controller-manager.json
@@ -1,941 +1,527 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "format": "none",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "gridPos": { },
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
+               "expr": "sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
+               "instant": true
+            }
+         ],
+         "title": "Up",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 20,
+            "x": 4,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 2,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Up",
-               "tooltip": {
-                  "shared": false
+               "expr": "sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
+               "legendFormat": "{{cluster}} {{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Add Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "valueName": "min"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
+               "legendFormat": "{{cluster}} {{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Depth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name, le))",
+               "legendFormat": "{{cluster}} {{instance}} {{name}}"
+            }
+         ],
+         "title": "Work Queue Latency",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 21
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+               "legendFormat": "2xx"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Add Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Depth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (cluster, instance, name, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Work Queue Latency",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "2xx",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "3xx",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "4xx",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "5xx",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Kube API Request Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+               "legendFormat": "3xx"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 8,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Post Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Get Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+               "legendFormat": "4xx"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+               "legendFormat": "5xx"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Kube API Request Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 21
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Post Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 28
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Get Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 35
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Memory",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 35
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "CPU usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 35
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Goroutines",
+         "type": "timeseries"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -943,57 +529,43 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-controller-manager\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "instance",
             "name": "instance",
-            "options": [ ],
             "query": "label_values(up{cluster=\"$cluster\", job=\"kube-controller-manager\"}, instance)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1001,33 +573,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Controller Manager",
-   "uid": "72e0e05bef5099e5f049b05fdc429ed4",
-   "version": 0
+   "uid": "72e0e05bef5099e5f049b05fdc429ed4"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-cluster.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-cluster.json
@@ -1,2598 +1,1524 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "100px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Utilisation",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Requests Commitment",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Limits Commitment",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Utilisation",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Requests Commitment",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 2,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Limits Commitment",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "cluster:node_cpu:ratio_rate5m{cluster=\"$cluster\"}",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Headlines",
-         "titleSize": "h6"
+         "title": "CPU Utilisation",
+         "type": "stat"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 4,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "CPU",
-         "titleSize": "h6"
+         "title": "CPU Requests Commitment",
+         "type": "stat"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 8,
+            "y": 0
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Pods",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Workloads",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to workloads",
-                     "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #G",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Namespace",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                     "pattern": "namespace",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "G"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"cpu\",cluster=\"$cluster\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "title": "CPU Limits Commitment",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 12,
+            "y": 0
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
+               "instant": true
+            }
+         ],
+         "title": "Memory Utilisation",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 16,
+            "y": 0
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
+               "instant": true
+            }
+         ],
+         "title": "Memory Requests Commitment",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 4,
+            "x": 20,
+            "y": 0
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{job=\"kube-state-metrics\",resource=\"memory\",cluster=\"$cluster\"})",
+               "instant": true
+            }
+         ],
+         "title": "Memory Limits Commitment",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               }
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 6
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "CPU Usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 12
+         },
+         "id": 8,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\"}) by (namespace) / sum(namespace_cpu:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage (w/o cache)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "joinByField",
+               "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Value #A": 8,
+                     "Value #B": 9,
+                     "Value #C": 10,
+                     "Value #D": 11,
+                     "Value #E": 12,
+                     "Value #F": 13,
+                     "Value #G": 14,
+                     "namespace": 7
+                  },
+                  "renameByName": {
+                     "Value #A": "Pods",
+                     "Value #B": "Workloads",
+                     "Value #C": "CPU Usage",
+                     "Value #D": "CPU Requests",
+                     "Value #E": "CPU Requests %",
+                     "Value #F": "CPU Limits",
+                     "Value #G": "CPU Limits %",
+                     "namespace": "Namespace"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 18
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
          "title": "Memory",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Memory Usage"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Memory Requests"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Memory Limits"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "bytes"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 24
+         },
+         "id": 10,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Pods",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Workloads",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to workloads",
-                     "linkUrl": "/d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Memory Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #G",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Namespace",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                     "pattern": "namespace",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  },
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "G"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Requests by Namespace",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(kube_pod_owner{job=\"kube-state-metrics\", cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(namespace_memory:kube_pod_container_resource_limits:sum{cluster=\"$cluster\"}) by (namespace)",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Memory Requests",
-         "titleSize": "h6"
+         "title": "Memory Requests by Namespace",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Value #A": 8,
+                     "Value #B": 9,
+                     "Value #C": 10,
+                     "Value #D": 11,
+                     "Value #E": 12,
+                     "Value #F": 13,
+                     "Value #G": 14,
+                     "namespace": 7
+                  },
+                  "renameByName": {
+                     "Value #A": "Pods",
+                     "Value #B": "Workloads",
+                     "Value #C": "Memory Usage",
+                     "Value #D": "Memory Requests",
+                     "Value #E": "Memory Requests %",
+                     "Value #F": "Memory Limits",
+                     "Value #G": "Memory Limits %",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bandwidth/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 30
+         },
+         "id": 11,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Current Receive Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Current Transmit Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Namespace",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                     "pattern": "namespace",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Network Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "Current Network Usage",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Receive Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "id": "joinByField",
+               "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+               }
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Transmit Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "namespace": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "Current Receive Bandwidth",
+                     "Value #B": "Current Transmit Bandwidth",
+                     "Value #C": "Rate of Received Packets",
+                     "Value #D": "Rate of Transmitted Packets",
+                     "Value #E": "Rate of Received Packets Dropped",
+                     "Value #F": "Rate of Transmitted Packets Dropped",
+                     "namespace": "Namespace"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 14,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 36
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Namespace: Received",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 42
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 48
+         },
+         "id": 14,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Container Bandwidth by Namespace: Received",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 54
+         },
+         "id": 15,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Container Bandwidth by Namespace: Transmitted",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 60
+         },
+         "id": 16,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 66
+         },
+         "id": 17,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 72
+         },
+         "id": 18,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 78
+         },
+         "id": 19,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "iops"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 84
+         },
+         "id": 20,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m])))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "IOPS(Reads+Writes)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 90
+         },
+         "id": 21,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "ThroughPut(Read+Write)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/IOPS/"
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "iops"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Throughput/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Namespace"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?${datasource:queryparam}&var-cluster=$cluster&var-namespace=${__data.fields.Namespace}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 96
+         },
+         "id": 22,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 15,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Namespace: Transmitted",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Container Bandwidth by Namespace",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 16,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 17,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 18,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 19,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets Dropped",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "decimals": -1,
-               "fill": 10,
-               "id": 20,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "IOPS(Reads+Writes)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 21,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{namespace}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ThroughPut(Read+Write)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+               "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 22,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "sort": {
-                  "col": 4,
-                  "desc": true
-               },
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "IOPS(Reads)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Reads + Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Throughput(Read)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Read + Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Namespace",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
-                     "pattern": "namespace",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Storage IO",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO - Distribution",
-         "titleSize": "h6"
+         "title": "Current Storage IO",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "namespace",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "namespace": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "IOPS(Reads)",
+                     "Value #B": "IOPS(Writes)",
+                     "Value #C": "IOPS(Reads + Writes)",
+                     "Value #D": "Throughput(Read)",
+                     "Value #E": "Throughput(Write)",
+                     "Value #F": "Throughput(Read + Write)",
+                     "namespace": "Namespace"
+                  }
+               }
+            }
+         ],
+         "type": "table"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -2600,40 +1526,29 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -2641,33 +1556,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Cluster",
-   "uid": "efa86fd1d0c121a26444b636a3f509a8",
-   "version": 0
+   "uid": "efa86fd1d0c121a26444b636a3f509a8"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-namespace.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-namespace.json
@@ -1,2323 +1,1442 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "100px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Utilisation (from requests)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Utilisation (from limits)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Utilisation (from requests)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "format": "percentunit",
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 3,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
-                     "format": "time_series",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "70,80",
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Utilisation (from limits)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "singlestat",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Headlines",
-         "titleSize": "h6"
+         "title": "CPU Utilisation (from requests)",
+         "type": "stat"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "quota - requests",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  },
-                  {
-                     "alias": "quota - limits",
-                     "color": "#FF9830",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "title": "CPU Utilisation (from limits)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 0
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+               "instant": true
+            }
+         ],
+         "title": "Memory Utilisation (from requests)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "percentunit"
+            }
+         },
+         "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+               "instant": true
+            }
+         ],
+         "title": "Memory Utilisation (from limits)",
+         "type": "stat"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "legendFormat": "__auto"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+               "legendFormat": "quota - requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+               "legendFormat": "quota - limits"
+            }
+         ],
          "title": "CPU Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 6,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "quota - requests",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true
                   },
-                  {
-                     "alias": "quota - limits",
-                     "color": "#FF9830",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Value #A": 6,
+                     "Value #B": 7,
+                     "Value #C": 8,
+                     "Value #D": 9,
+                     "Value #E": 10,
+                     "pod": 5
+                  },
+                  "renameByName": {
+                     "Value #A": "CPU Usage",
+                     "Value #B": "CPU Requests",
+                     "Value #C": "CPU Requests %",
+                     "Value #D": "CPU Limits",
+                     "Value #E": "CPU Limits %",
+                     "pod": "Pod"
                   }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage (w/o cache)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Memory Usage",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Memory Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Usage (RSS)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Cache)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #G",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Swap)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #H",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  },
-                  {
-                     "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "G"
-                  },
-                  {
-                     "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "H"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
+               "legendFormat": "__auto"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+               "legendFormat": "quota - requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+               "legendFormat": "quota - limits"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "title": "Memory Usage (w/o cache)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 28
+         },
+         "id": 8,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Memory Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true,
+                     "Time 8": true
                   },
-                  {
-                     "alias": "Current Receive Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Time 8": 7,
+                     "Value #A": 9,
+                     "Value #B": 10,
+                     "Value #C": 11,
+                     "Value #D": 12,
+                     "Value #E": 13,
+                     "Value #F": 14,
+                     "Value #G": 15,
+                     "Value #H": 16,
+                     "pod": 8
                   },
-                  {
-                     "alias": "Current Transmit Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
+                  "renameByName": {
+                     "Value #A": "Memory Usage",
+                     "Value #B": "Memory Requests",
+                     "Value #C": "Memory Requests %",
+                     "Value #D": "Memory Limits",
+                     "Value #E": "Memory Limits %",
+                     "Value #F": "Memory Usage (RSS)",
+                     "Value #G": "Memory Usage (Cache)",
+                     "Value #H": "Memory Usage (Swap)",
+                     "pod": "Pod"
                   }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Network Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bandwidth/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 35
+         },
+         "id": 9,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Current Network Usage",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Receive Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Transmit Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "pod": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "Current Receive Bandwidth",
+                     "Value #B": "Current Transmit Bandwidth",
+                     "Value #C": "Rate of Received Packets",
+                     "Value #D": "Rate of Transmitted Packets",
+                     "Value #E": "Rate of Received Packets Dropped",
+                     "Value #F": "Rate of Transmitted Packets Dropped",
+                     "pod": "Pod"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 49
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 49
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 56
+         },
+         "id": 14,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 56
+         },
+         "id": 15,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "iops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 63
+         },
+         "id": 16,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "IOPS(Reads+Writes)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 63
+         },
+         "id": 17,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "ThroughPut(Read+Write)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/IOPS/"
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "iops"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Throughput/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 70
+         },
+         "id": 18,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 14,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 15,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets Dropped",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "decimals": -1,
-               "fill": 10,
-               "id": 16,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "IOPS(Reads+Writes)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 17,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{id!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ThroughPut(Read+Write)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+               "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 18,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "sort": {
-                  "col": 4,
-                  "desc": true
+               "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "IOPS(Reads)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Reads + Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Throughput(Read)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Read + Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Storage IO",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO - Distribution",
-         "titleSize": "h6"
+         "title": "Current Storage IO",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "pod": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "IOPS(Reads)",
+                     "Value #B": "IOPS(Writes)",
+                     "Value #C": "IOPS(Reads + Writes)",
+                     "Value #D": "Throughput(Read)",
+                     "Value #E": "Throughput(Write)",
+                     "Value #F": "Throughput(Read + Write)",
+                     "pod": "Pod"
+                  }
+               }
+            }
+         ],
+         "type": "table"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -2325,63 +1444,42 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -2389,33 +1487,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Namespace (Pods)",
-   "uid": "85a562078cdf77779eaa1add43ccec1e",
-   "version": 0
+   "uid": "85a562078cdf77779eaa1add43ccec1e"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-node.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-node.json
@@ -1,770 +1,502 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "max capacity"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "none"
+                        }
+                     },
+                     {
+                        "id": "custom.hideFrom",
+                        "value": {
+                           "legend": false,
+                           "tooltip": true,
+                           "viz": false
+                        }
+                     },
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "dash": [
+                              10,
+                              10
+                           ],
+                           "fill": "dash"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "max capacity",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "max capacity",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
+               "legendFormat": "max capacity"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "legendFormat": "{{pod}}"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 6
+         },
+         "id": 2,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "max capacity",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "max capacity",
-                     "legendLink": null
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true
                   },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
+                  "renameByName": {
+                     "Value #A": "CPU Usage",
+                     "Value #B": "CPU Requests",
+                     "Value #C": "CPU Requests %",
+                     "Value #D": "CPU Limits",
+                     "Value #E": "CPU Limits %",
+                     "pod": "Pod"
                   }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage (w/o cache)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Memory Usage",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                     "mode": "normal"
+                  }
+               },
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "max capacity"
+                  },
+                  "properties": [
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     },
+                     {
+                        "id": "custom.stacking",
+                        "value": {
+                           "mode": "none"
+                        }
+                     },
+                     {
+                        "id": "custom.hideFrom",
+                        "value": {
+                           "legend": false,
+                           "tooltip": true,
+                           "viz": false
+                        }
+                     },
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "dash": [
+                              10,
+                              10
+                           ],
+                           "fill": "dash"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 12
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Memory Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Usage (RSS)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Cache)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #G",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Swap)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #H",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "G"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "H"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
+               "legendFormat": "max capacity"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
+               "legendFormat": "{{pod}}"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "title": "Memory Usage (w/o cache)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 18
+         },
+         "id": 4,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Memory Quota",
-         "titleSize": "h6"
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true,
+                     "Time 8": true
+                  },
+                  "renameByName": {
+                     "Value #A": "Memory Usage",
+                     "Value #B": "Memory Requests",
+                     "Value #C": "Memory Requests %",
+                     "Value #D": "Memory Limits",
+                     "Value #E": "Memory Limits %",
+                     "Value #F": "Memory Usage (RSS)",
+                     "Value #G": "Memory Usage (Cache)",
+                     "Value #H": "Memory Usage (Swap)",
+                     "pod": "Pod"
+                  }
+               }
+            }
+         ],
+         "type": "table"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -772,63 +504,42 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
+            "label": "node",
             "multi": true,
             "name": "node",
-            "options": [ ],
             "query": "label_values(kube_node_info{cluster=\"$cluster\"}, node)",
             "refresh": 2,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -836,33 +547,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Node (Pods)",
-   "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
-   "version": 0
+   "uid": "200ac8fdbfbb74b39aff88118e4d1c2c"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-pod.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-pod.json
@@ -1,2015 +1,1295 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "requests",
-                     "color": "#F2495C",
-                     "fill": 0,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  },
-                  {
-                     "alias": "limits",
-                     "color": "#FF9830",
-                     "fill": 0,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}) by (container)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{container}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\", container!=\"\"}) by (container)",
+               "legendFormat": "__auto"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+               "legendFormat": "requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+               "legendFormat": "limits"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{container}}",
-                     "legendLink": null
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "axisColorMode": "thresholds",
+                  "axisSoftMax": 1,
+                  "axisSoftMin": 0,
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "thresholdsStyle": {
+                     "mode": "dashed+area"
                   }
-               ],
-               "thresholds": [
-                  {
-                     "colorMode": "critical",
-                     "fill": true,
-                     "line": true,
-                     "op": "gt",
-                     "value": 0.25,
-                     "yaxis": "left"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Throttling",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "percentunit",
-                     "label": null,
-                     "logBase": 1,
-                     "max": 1,
-                     "min": 0,
-                     "show": true
+               "unit": "percentunit"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "A"
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+                  "properties": [
+                     {
+                        "id": "thresholds",
+                        "value": {
+                           "mode": "absolute",
+                           "steps": [
+                              {
+                                 "color": "green",
+                                 "value": null
+                              },
+                              {
+                                 "color": "red",
+                                 "value": 0.25
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "mode": "thresholds",
+                           "seriesBy": "lastNotNull"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Throttling",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 3,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Container",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "container",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "requests",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+               "id": "joinByField",
+               "options": {
+                  "byField": "container",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true
                   },
-                  {
-                     "alias": "limits",
-                     "color": "#FF9830",
-                     "dashes": true,
-                     "fill": 0,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Value #A": 6,
+                     "Value #B": 7,
+                     "Value #C": 8,
+                     "Value #D": 9,
+                     "Value #E": 10,
+                     "container": 5
+                  },
+                  "renameByName": {
+                     "Value #A": "CPU Usage",
+                     "Value #B": "CPU Requests",
+                     "Value #C": "CPU Requests %",
+                     "Value #D": "CPU Limits",
+                     "Value #E": "CPU Limits %",
+                     "container": "Container"
                   }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{container}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage (WSS)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Memory Usage",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Memory Usage (WSS)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Usage (RSS)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Cache)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #G",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Usage (Swap)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #H",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Container",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "container",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  },
-                  {
-                     "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "G"
-                  },
-                  {
-                     "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "H"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+               "legendFormat": "__auto"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+               "legendFormat": "requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+               "legendFormat": "limits"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "title": "Memory Usage (WSS)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 28
+         },
+         "id": 5,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_rss{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_cache{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(container_memory_swap{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Memory Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Receive Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "id": "joinByField",
+               "options": {
+                  "byField": "container",
+                  "mode": "outer"
+               }
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Transmit Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true,
+                     "Time 8": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Time 8": 7,
+                     "Value #A": 9,
+                     "Value #B": 10,
+                     "Value #C": 11,
+                     "Value #D": 12,
+                     "Value #E": 13,
+                     "Value #F": 14,
+                     "Value #G": 15,
+                     "Value #H": 16,
+                     "container": 8
+                  },
+                  "renameByName": {
+                     "Value #A": "Memory Usage",
+                     "Value #B": "Memory Requests",
+                     "Value #C": "Memory Requests %",
+                     "Value #D": "Memory Limits",
+                     "Value #E": "Memory Limits %",
+                     "Value #F": "Memory Usage (RSS)",
+                     "Value #G": "Memory Usage (Cache)",
+                     "Value #H": "Memory Usage (Swap)",
+                     "container": "Container"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 35
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 35
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 49
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 49
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "iops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 56
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+               "legendFormat": "Reads"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+               "legendFormat": "Writes"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets",
-         "titleSize": "h6"
+         "title": "IOPS (Pod)",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 56
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+               "legendFormat": "Reads"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+               "legendFormat": "Writes"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets Dropped",
-         "titleSize": "h6"
+         "title": "ThroughPut (Pod)",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "decimals": -1,
-               "fill": 10,
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Reads",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Writes",
-                     "legendLink": null
-                  }
+               "unit": "iops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 63
+         },
+         "id": 14,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "IOPS",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "ceil(sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m])))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "IOPS (Containers)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 63
+         },
+         "id": 15,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "ThroughPut (Containers)",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/IOPS/"
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "iops"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Throughput/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 70
+         },
+         "id": 16,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Reads",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "Writes",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ThroughPut",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO - Distribution(Pod - Read & Writes)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "decimals": -1,
-               "fill": 10,
-               "id": 14,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "ceil(sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m])))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{container}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "IOPS(Reads+Writes)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 15,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{container}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "ThroughPut(Read+Write)",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO - Distribution(Containers)",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+               "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 16,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "sort": {
-                  "col": 4,
-                  "desc": true
+               "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "IOPS(Reads)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "IOPS(Reads + Writes)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": -1,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Throughput(Read)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Throughput(Read + Write)",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Container",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "container",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum by(container) (rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum by(container) (rate(container_fs_reads_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Storage IO",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum by(container) (rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum by(container) (rate(container_fs_reads_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", id!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Storage IO - Distribution",
-         "titleSize": "h6"
+         "title": "Current Storage IO",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "container",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "container": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "IOPS(Reads)",
+                     "Value #B": "IOPS(Writes)",
+                     "Value #C": "IOPS(Reads + Writes)",
+                     "Value #D": "Throughput(Read)",
+                     "Value #E": "Throughput(Write)",
+                     "Value #F": "Throughput(Read + Write)",
+                     "container": "Container"
+                  }
+               }
+            }
+         ],
+         "type": "table"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -2017,86 +1297,55 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "pod",
             "name": "pod",
-            "options": [ ],
             "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\"}, pod)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -2104,33 +1353,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Pod",
-   "uid": "6581e46e4e5c7ba40a07646395ef7b23",
-   "version": 0
+   "uid": "6581e46e4e5c7ba40a07646395ef7b23"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workload.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workload.json
@@ -1,1591 +1,963 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               }
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+         },
+         "id": 2,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Value #A": 6,
+                     "Value #B": 7,
+                     "Value #C": 8,
+                     "Value #D": 9,
+                     "Value #E": 10,
+                     "pod": 5
+                  },
+                  "renameByName": {
+                     "Value #A": "CPU Usage",
+                     "Value #B": "CPU Requests",
+                     "Value #C": "CPU Requests %",
+                     "Value #D": "CPU Limits",
+                     "Value #E": "CPU Limits %",
+                     "pod": "Pod"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "legendFormat": "__auto"
+            }
+         ],
          "title": "Memory Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 4,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Memory Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=~\"$type\"}\n) by (pod)\n",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "Memory Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true
                   },
-                  {
-                     "alias": "Current Receive Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Value #A": 9,
+                     "Value #B": 10,
+                     "Value #C": 11,
+                     "Value #D": 12,
+                     "Value #E": 13,
+                     "pod": 8
                   },
-                  {
-                     "alias": "Current Transmit Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Pod",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
-                     "pattern": "pod",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
+                  "renameByName": {
+                     "Value #A": "Memory Usage",
+                     "Value #B": "Memory Requests",
+                     "Value #C": "Memory Requests %",
+                     "Value #D": "Memory Limits",
+                     "Value #E": "Memory Limits %",
+                     "pod": "Pod"
                   }
-               ],
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Network Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bandwidth/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to pods",
+                              "url": "/d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 28
+         },
+         "id": 5,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Current Network Usage",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Receive Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Transmit Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "pod": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "Current Receive Bandwidth",
+                     "Value #B": "Current Transmit Bandwidth",
+                     "Value #C": "Rate of Received Packets",
+                     "Value #D": "Rate of Transmitted Packets",
+                     "Value #E": "Rate of Received Packets Dropped",
+                     "Value #F": "Rate of Transmitted Packets Dropped",
+                     "pod": "Pod"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 35
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Pod: Received",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Pod: Transmitted",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Container Bandwidth by Pod",
-         "titleSize": "h6"
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 35
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets",
-         "titleSize": "h6"
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{pod}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets Dropped",
-         "titleSize": "h6"
+         "title": "Average Container Bandwidth by Pod: Received",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Container Bandwidth by Pod: Transmitted",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 49
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 49
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 56
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 56
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1593,109 +965,69 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "includeAll": true,
+            "label": "workload_type",
             "name": "type",
-            "options": [ ],
             "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\"}, workload_type)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "workload",
             "name": "workload",
-            "options": [ ],
-            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}, workload)",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}, workload)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1703,33 +1035,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Workload",
-   "uid": "a164a7f0339f99e89cea5cb47e9be617",
-   "version": 0
+   "uid": "a164a7f0339f99e89cea5cb47e9be617"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workloads-namespace.json
+++ b/resources/mixins/kubernetes/generated/dashboards/k8s-resources-workloads-namespace.json
@@ -1,1756 +1,1173 @@
 {
-   "annotations": {
-      "list": [ ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "editable": false,
+   "panels": [
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               }
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 1,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "quota - requests",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  },
-                  {
-                     "alias": "quota - limits",
-                     "color": "#FF9830",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
-                  }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}} - {{workload_type}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "legendFormat": "{{workload}} - {{workload_type}}"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+               "legendFormat": "quota - requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+               "legendFormat": "quota - limits"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Workload"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to workloads",
+                              "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Running Pods"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 7
+         },
+         "id": 2,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Running Pods",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "CPU Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "CPU Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Workload",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
-                     "pattern": "workload",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Workload Type",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "workload_type",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "CPU Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [
-                  {
-                     "alias": "quota - requests",
-                     "color": "#F2495C",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+               "id": "joinByField",
+               "options": {
+                  "byField": "workload",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "workload_type 2": true,
+                     "workload_type 3": true,
+                     "workload_type 4": true,
+                     "workload_type 5": true,
+                     "workload_type 6": true
                   },
-                  {
-                     "alias": "quota - limits",
-                     "color": "#FF9830",
-                     "dashes": true,
-                     "fill": 0,
-                     "hiddenSeries": true,
-                     "hideTooltip": true,
-                     "legend": true,
-                     "linewidth": 2,
-                     "stack": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 8,
+                     "Value #B": 9,
+                     "Value #C": 10,
+                     "Value #D": 11,
+                     "Value #E": 12,
+                     "Value #F": 13,
+                     "workload": 6,
+                     "workload_type 1": 7,
+                     "workload_type 2": 14,
+                     "workload_type 3": 15,
+                     "workload_type 4": 16,
+                     "workload_type 5": 17,
+                     "workload_type 6": 18
+                  },
+                  "renameByName": {
+                     "Value #A": "Running Pods",
+                     "Value #B": "CPU Usage",
+                     "Value #C": "CPU Requests",
+                     "Value #D": "CPU Requests %",
+                     "Value #E": "CPU Limits",
+                     "Value #F": "CPU Limits %",
+                     "workload": "Workload",
+                     "workload_type 1": "Type"
                   }
-               ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}} - {{workload_type}}",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - requests",
-                     "legendLink": null
-                  },
-                  {
-                     "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "quota - limits",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "B"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "red",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byFrameRefID",
+                     "options": "C"
+                  },
+                  "properties": [
+                     {
+                        "id": "custom.lineStyle",
+                        "value": {
+                           "fill": "dash"
+                        }
+                     },
+                     {
+                        "id": "custom.lineWidth",
+                        "value": 2
+                     },
+                     {
+                        "id": "color",
+                        "value": {
+                           "fixedColor": "orange",
+                           "mode": "fixed"
+                        }
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "legendFormat": "{{workload}} - {{workload_type}}"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+               "legendFormat": "quota - requests"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+               "legendFormat": "quota - limits"
+            }
+         ],
          "title": "Memory Usage",
-         "titleSize": "h6"
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "bytes"
+            },
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/%/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "percentunit"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Workload"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to workloads",
+                              "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                           }
+                        ]
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Running Pods"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "none"
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 4,
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Running Pods",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 0,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Memory Usage",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Requests %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Memory Limits",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "bytes"
-                  },
-                  {
-                     "alias": "Memory Limits %",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "percentunit"
-                  },
-                  {
-                     "alias": "Workload",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
-                     "pattern": "workload",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Workload Type",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "workload_type",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory Quota",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
+               "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload, workload_type)",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(\n    container_memory_working_set_bytes{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{job=\"kube-state-metrics\", cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}\n) by (workload, workload_type)\n",
+               "format": "table",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
          "title": "Memory Quota",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "styles": [
-                  {
-                     "alias": "Time",
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "pattern": "Time",
-                     "type": "hidden"
+               "id": "joinByField",
+               "options": {
+                  "byField": "workload",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "workload_type 2": true,
+                     "workload_type 3": true,
+                     "workload_type 4": true,
+                     "workload_type 5": true,
+                     "workload_type 6": true
                   },
-                  {
-                     "alias": "Current Receive Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #A",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 8,
+                     "Value #B": 9,
+                     "Value #C": 10,
+                     "Value #D": 11,
+                     "Value #E": 12,
+                     "Value #F": 13,
+                     "workload": 6,
+                     "workload_type 1": 7,
+                     "workload_type 2": 14,
+                     "workload_type 3": 15,
+                     "workload_type 4": 16,
+                     "workload_type 5": 17,
+                     "workload_type 6": 18
                   },
-                  {
-                     "alias": "Current Transmit Bandwidth",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #B",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "Bps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #C",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #D",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Received Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #E",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Rate of Transmitted Packets Dropped",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "Value #F",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "pps"
-                  },
-                  {
-                     "alias": "Workload",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": true,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down to pods",
-                     "linkUrl": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type",
-                     "pattern": "workload",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "Workload Type",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "link": false,
-                     "linkTargetBlank": false,
-                     "linkTooltip": "Drill down",
-                     "linkUrl": "",
-                     "pattern": "workload_type",
-                     "thresholds": [ ],
-                     "type": "number",
-                     "unit": "short"
-                  },
-                  {
-                     "alias": "",
-                     "colorMode": null,
-                     "colors": [ ],
-                     "dateFormat": "YYYY-MM-DD HH:mm:ss",
-                     "decimals": 2,
-                     "pattern": "/.*/",
-                     "thresholds": [ ],
-                     "type": "string",
-                     "unit": "short"
+                  "renameByName": {
+                     "Value #A": "Running Pods",
+                     "Value #B": "Memory Usage",
+                     "Value #C": "Memory Requests",
+                     "Value #D": "Memory Requests %",
+                     "Value #E": "Memory Limits",
+                     "Value #F": "Memory Limits %",
+                     "workload": "Workload",
+                     "workload_type 1": "Type"
                   }
-               ],
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "D"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "E"
-                  },
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "F"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Current Network Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "transform": "table",
-               "type": "table",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
+         "type": "table"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bandwidth/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Workload"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down to workloads",
+                              "url": "/d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?${datasource:queryparam}&var-cluster=$cluster&var-namespace=$namespace&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 28
+         },
+         "id": 5,
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+               "format": "table",
+               "instant": true
+            }
+         ],
          "title": "Current Network Usage",
-         "titleSize": "h6"
-      },
-      {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
+         "transformations": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Receive Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "id": "joinByField",
+               "options": {
+                  "byField": "workload",
+                  "mode": "outer"
+               }
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Transmit Bandwidth",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
                   },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "workload": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "Current Receive Bandwidth",
+                     "Value #B": "Current Transmit Bandwidth",
+                     "Value #C": "Rate of Received Packets",
+                     "Value #D": "Rate of Transmitted Packets",
+                     "Value #E": "Rate of Received Packets Dropped",
+                     "Value #F": "Rate of Transmitted Packets Dropped",
+                     "workload": "Workload"
                   }
-               ]
+               }
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6"
+         "type": "table"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 35
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Workload: Received",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Container Bandwidth by Workload: Transmitted",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Container Bandwidth by Workload",
-         "titleSize": "h6"
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 35
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets",
-         "titleSize": "h6"
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "height": "250px",
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 42
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 10,
-               "id": 13,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 0,
-               "links": [ ],
-               "nullPointMode": "null as zero",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{workload}}",
-                     "legendLink": null
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": false
-                  }
-               ]
+               "expr": "(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Rate of Packets Dropped",
-         "titleSize": "h6"
+         "title": "Average Container Bandwidth by Workload: Received",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 42
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Average Container Bandwidth by Workload: Transmitted",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 49
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 49
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 56
+         },
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 56
+         },
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1758,91 +1175,56 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
-            "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
+            "query": "label_values(kube_namespace_status_phase{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "deployment",
-               "value": "deployment"
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "includeAll": true,
+            "label": "workload_type",
             "name": "type",
-            "options": [ ],
             "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          }
       ]
    },
@@ -1850,33 +1232,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
-   "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
-   "version": 0
+   "uid": "a87fb0d919ec0ea5f6543124e16c42a5"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/kubelet.json
+++ b/resources/mixins/kubernetes/generated/dashboards/kubelet.json
@@ -1,26 +1,13 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
    "panels": [
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -30,46 +17,32 @@
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "links": [ ],
+         "id": 1,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(kubelet_node_name{cluster=\"$cluster\", job=\"kubelet\"})",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
+               "instant": true
             }
          ],
          "title": "Running Kubelets",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -79,46 +52,32 @@
             "x": 4,
             "y": 0
          },
-         "id": 3,
-         "links": [ ],
+         "id": 2,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(kubelet_running_pods{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_pod_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(kubelet_running_pods{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+               "instant": true
             }
          ],
          "title": "Running Pods",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -128,46 +87,32 @@
             "x": 8,
             "y": 0
          },
-         "id": 4,
-         "links": [ ],
+         "id": 3,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(kubelet_running_containers{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_container_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(kubelet_running_containers{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+               "instant": true
             }
          ],
          "title": "Running Containers",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -177,46 +122,32 @@
             "x": 12,
             "y": 0
          },
-         "id": 5,
-         "links": [ ],
+         "id": 4,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\", state=\"actual_state_of_world\"})",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "instant": true
             }
          ],
          "title": "Actual Volume Count",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -226,46 +157,32 @@
             "x": 16,
             "y": 0
          },
-         "id": 6,
-         "links": [ ],
+         "id": 5,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\",state=\"desired_state_of_world\"})",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "instant": true
             }
          ],
          "title": "Desired Volume Count",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "datasource": "$datasource",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
          "fieldConfig": {
             "defaults": {
-               "links": [ ],
-               "mappings": [ ],
-               "thresholds": {
-                  "mode": "absolute",
-                  "steps": [ ]
-               },
                "unit": "none"
             }
          },
@@ -275,1613 +192,986 @@
             "x": 20,
             "y": 0
          },
-         "id": 7,
-         "links": [ ],
+         "id": 6,
+         "interval": "1m",
          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-               "calcs": [
-                  "lastNotNull"
-               ],
-               "fields": "",
-               "values": false
-            },
-            "textMode": "auto"
+            "colorMode": "none"
          },
-         "pluginVersion": "7",
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(kubelet_node_config_error{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "instant": true
             }
          ],
          "title": "Config Error Count",
-         "transparent": false,
          "type": "stat"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
             "y": 7
          },
-         "id": 8,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(kubelet_runtime_operations_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (operation_type, instance)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_type}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_type}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Operation Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
             "y": 7
          },
-         "id": 9,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(kubelet_runtime_operations_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_type}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_type}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Operation Error Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
             "y": 14
          },
-         "id": 10,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_type}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_type}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Operation duration 99th quantile",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "title": "Operation Duration 99th quantile",
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
+            "y": 21
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+               "legendFormat": "{{instance}} pod"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+               "legendFormat": "{{instance}} worker"
+            }
+         ],
+         "title": "Pod Start Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
             "y": 21
          },
          "id": 11,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} pod",
-               "refId": "A"
-            },
-            {
-               "expr": "sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} worker",
-               "refId": "B"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Pod Start Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 21
-         },
-         "id": 12,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} pod",
-               "refId": "A"
+               "legendFormat": "{{instance}} pod"
             },
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} worker",
-               "refId": "B"
+               "legendFormat": "{{instance}} worker"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Pod Start Duration",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
             "y": 28
          },
-         "id": 13,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 12,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(storage_operation_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Storage Operation Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
             "y": 28
          },
-         "id": 14,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 13,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(storage_operation_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Storage Operation Error Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
             "y": 35
          },
-         "id": 15,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 14,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Storage Operation Duration 99th quantile",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
+            "y": 42
+         },
+         "id": 15,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type)",
+               "legendFormat": "{{operation_type}}"
+            }
+         ],
+         "title": "Cgroup manager operation rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
             "y": 42
          },
          "id": 16,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{operation_type}}",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Cgroup manager operation rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
+            "tooltip": {
+               "mode": "single"
             }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 42
          },
-         "id": 17,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{operation_type}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{operation_type}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Cgroup manager 99th quantile",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "description": "Pod lifecycle event generator",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
             "y": 49
          },
-         "id": 18,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 17,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(kubelet_pleg_relist_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "PLEG relist rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
             "y": 49
          },
-         "id": 19,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 18,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "PLEG relist interval",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
             "y": 56
          },
-         "id": 20,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 19,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "PLEG relist duration",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
             "y": 63
          },
-         "id": 21,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 20,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "2xx",
-               "refId": "A"
+               "legendFormat": "2xx"
             },
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "3xx",
-               "refId": "B"
+               "legendFormat": "3xx"
             },
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "4xx",
-               "refId": "C"
+               "legendFormat": "4xx"
             },
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "5xx",
-               "refId": "D"
+               "legendFormat": "5xx"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "RPC Rate",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "ops",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "title": "RPC rate",
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 24,
             "x": 0,
             "y": 70
          },
-         "id": 22,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": true
+         "id": 21,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, verb, url, le))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}} {{verb}} {{url}}",
-               "refId": "A"
+               "legendFormat": "{{instance}} {{verb}} {{url}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Request duration 99th quantile",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "s",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
             "x": 0,
             "y": 77
          },
-         "id": 23,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 22,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "process_resident_memory_bytes{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Memory",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
             "x": 8,
             "y": 77
          },
-         "id": 24,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 23,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "CPU usage",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 1,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
          "gridPos": {
             "h": 7,
             "w": 8,
             "x": 16,
             "y": 77
          },
-         "id": 25,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 24,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
                "expr": "go_goroutines{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "{{instance}}",
-               "refId": "A"
+               "legendFormat": "{{instance}}"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Goroutines",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1889,57 +1179,42 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
             "label": "instance",
-            "multi": false,
             "name": "instance",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",cluster=\"$cluster\"}, instance)",
             "refresh": 2,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1947,33 +1222,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Kubelet",
-   "uid": "3138fa155d5915769fbded898ac09fd9",
-   "version": 0
+   "uid": "3138fa155d5915769fbded898ac09fd9"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/namespace-by-pod.json
+++ b/resources/mixins/kubernetes/generated/dashboards/namespace-by-pod.json
@@ -1,1131 +1,555 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [
-         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-         }
-      ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "editable": false,
    "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "displayName": "$namespace",
+               "max": 10000000000,
+               "min": 0,
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "dark-green",
+                        "index": 0,
+                        "value": null
+                     },
+                     {
+                        "color": "dark-yellow",
+                        "index": 1,
+                        "value": 5000000000
+                     },
+                     {
+                        "color": "dark-red",
+                        "index": 2,
+                        "value": 7000000000
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Current Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "$datasource",
-         "decimals": 0,
-         "format": "time_series",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-         },
-         "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 1
-         },
-         "height": 9,
-         "id": 3,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "options": {
-            "fieldOptions": {
-               "calcs": [
-                  "last"
-               ],
-               "defaults": {
-                  "max": 10000000000,
-                  "min": 0,
-                  "title": "$namespace",
-                  "unit": "Bps"
-               },
-               "mappings": [ ],
-               "override": { },
-               "thresholds": [
-                  {
-                     "color": "dark-green",
-                     "index": 0,
-                     "value": null
-                  },
-                  {
-                     "color": "dark-yellow",
-                     "index": 1,
-                     "value": 5000000000
-                  },
-                  {
-                     "color": "dark-red",
-                     "index": 2,
-                     "value": 7000000000
-                  }
-               ],
-               "values": false
-            }
-         },
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "span": 12,
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
+         "id": 1,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
-               "format": "time_series",
-               "instant": null,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": "",
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Received",
-         "type": "gauge",
-         "valueFontSize": "80%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
+         "type": "gauge"
       },
       {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "$datasource",
-         "decimals": 0,
-         "format": "time_series",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "displayName": "$namespace",
+               "max": 10000000000,
+               "min": 0,
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "dark-green",
+                        "index": 0,
+                        "value": null
+                     },
+                     {
+                        "color": "dark-yellow",
+                        "index": 1,
+                        "value": 5000000000
+                     },
+                     {
+                        "color": "dark-red",
+                        "index": 2,
+                        "value": 7000000000
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            }
          },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 0
          },
-         "height": 9,
-         "id": 4,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "options": {
-            "fieldOptions": {
-               "calcs": [
-                  "last"
-               ],
-               "defaults": {
-                  "max": 10000000000,
-                  "min": 0,
-                  "title": "$namespace",
-                  "unit": "Bps"
-               },
-               "mappings": [ ],
-               "override": { },
-               "thresholds": [
-                  {
-                     "color": "dark-green",
-                     "index": 0,
-                     "value": null
-                  },
-                  {
-                     "color": "dark-yellow",
-                     "index": 1,
-                     "value": 5000000000
-                  },
-                  {
-                     "color": "dark-red",
-                     "index": 2,
-                     "value": 7000000000
-                  }
-               ],
-               "values": false
-            }
-         },
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "span": 12,
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
+         "id": 2,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
-               "format": "time_series",
-               "instant": null,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": "",
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Transmitted",
-         "type": "gauge",
-         "valueFontSize": "80%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
+         "type": "gauge"
       },
       {
-         "columns": [
-            {
-               "text": "Time",
-               "value": "Time"
-            },
-            {
-               "text": "Value #A",
-               "value": "Value #A"
-            },
-            {
-               "text": "Value #B",
-               "value": "Value #B"
-            },
-            {
-               "text": "Value #C",
-               "value": "Value #C"
-            },
-            {
-               "text": "Value #D",
-               "value": "Value #D"
-            },
-            {
-               "text": "Value #E",
-               "value": "Value #E"
-            },
-            {
-               "text": "Value #F",
-               "value": "Value #F"
-            },
-            {
-               "text": "pod",
-               "value": "pod"
-            }
-         ],
-         "datasource": "$datasource",
-         "fill": 1,
-         "fontSize": "100%",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bandwidth/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "Bps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Pod"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down",
+                              "url": "/d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-pod=${__data.fields.Pod}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 10
+            "y": 9
          },
-         "id": 5,
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null as zero",
-         "renderer": "flot",
-         "scroll": true,
-         "showHeader": true,
-         "sort": {
-            "col": 0,
-            "desc": false
-         },
-         "spaceLength": 10,
-         "span": 24,
-         "styles": [
-            {
-               "alias": "Time",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Time",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short"
-            },
-            {
-               "alias": "Bandwidth Received",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #A",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Bandwidth Transmitted",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #B",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Rate of Received Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #C",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #D",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Received Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #E",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #F",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Pod",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": true,
-               "linkTooltip": "Drill down",
-               "linkUrl": "d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell",
-               "pattern": "pod",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "short"
-            }
-         ],
+         "id": 3,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "B",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "C",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "D",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "E",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "F",
-               "step": 10
+               "instant": true
             }
          ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Current Status",
+         "title": "Current Network Usage",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "pod",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Value #A": 7,
+                     "Value #B": 8,
+                     "Value #C": 9,
+                     "Value #D": 10,
+                     "Value #E": 11,
+                     "Value #F": 12,
+                     "pod": 6
+                  },
+                  "renameByName": {
+                     "Value #A": "Current Receive Bandwidth",
+                     "Value #B": "Current Transmit Bandwidth",
+                     "Value #C": "Rate of Received Packets",
+                     "Value #D": "Rate of Transmitted Packets",
+                     "Value #E": "Rate of Received Packets Dropped",
+                     "Value #F": "Rate of Transmitted Packets Dropped",
+                     "pod": "Pod"
+                  }
+               }
+            }
+         ],
          "type": "table"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 19
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 6,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 18
          },
-         "id": 7,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Receive Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 18
          },
-         "id": 8,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Transmit Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 29
+            "y": 27
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 27
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 36
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum by (namespace) (rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"})",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 36
          },
          "id": 9,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 0,
-                  "y": 30
-               },
-               "id": 10,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 12,
-                  "y": 30
-               },
-               "id": 11,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+            "tooltip": {
+               "mode": "single"
             }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Packets",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 30
          },
-         "id": 12,
-         "panels": [
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
-               },
-               "id": 14,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) * on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Errors",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 18,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1133,141 +557,49 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
             "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          },
          {
             "allValue": ".+",
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
+               "selected": false,
                "text": "kube-system",
                "value": "kube-system"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "resolution",
-            "options": [
-               {
-                  "selected": false,
-                  "text": "30s",
-                  "value": "30s"
-               },
-               {
-                  "selected": true,
-                  "text": "5m",
-                  "value": "5m"
-               },
-               {
-                  "selected": false,
-                  "text": "1h",
-                  "value": "1h"
-               }
-            ],
-            "query": "30s,5m,1h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "interval",
-            "options": [
-               {
-                  "selected": true,
-                  "text": "4h",
-                  "value": "4h"
-               }
-            ],
-            "query": "4h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1275,33 +607,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Networking / Namespace (Pods)",
-   "uid": "8b7a8b326d7a6f1f04244066368c67af",
-   "version": 0
+   "uid": "8b7a8b326d7a6f1f04244066368c67af"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/namespace-by-workload.json
+++ b/resources/mixins/kubernetes/generated/dashboards/namespace-by-workload.json
@@ -1,1343 +1,701 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [
-         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-         }
-      ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "editable": false,
    "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Current Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 1
+         "id": 1,
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
          },
-         "id": 3,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
-         },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{ workload }}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Received",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "bargauge"
       },
       {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 0
          },
-         "id": 4,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
+         "id": 2,
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
          },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{ workload }}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Transmitted",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "bargauge"
       },
       {
-         "columns": [
-            {
-               "text": "Time",
-               "value": "Time"
-            },
-            {
-               "text": "Value #A",
-               "value": "Value #A"
-            },
-            {
-               "text": "Value #B",
-               "value": "Value #B"
-            },
-            {
-               "text": "Value #C",
-               "value": "Value #C"
-            },
-            {
-               "text": "Value #D",
-               "value": "Value #D"
-            },
-            {
-               "text": "Value #E",
-               "value": "Value #E"
-            },
-            {
-               "text": "Value #F",
-               "value": "Value #F"
-            },
-            {
-               "text": "Value #G",
-               "value": "Value #G"
-            },
-            {
-               "text": "Value #H",
-               "value": "Value #H"
-            },
-            {
-               "text": "workload",
-               "value": "workload"
-            }
-         ],
-         "datasource": "$datasource",
-         "fill": 1,
-         "fontSize": "90%",
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "overrides": [
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Bytes/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "binBps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byRegexp",
+                     "options": "/Packets/"
+                  },
+                  "properties": [
+                     {
+                        "id": "unit",
+                        "value": "pps"
+                     }
+                  ]
+               },
+               {
+                  "matcher": {
+                     "id": "byName",
+                     "options": "Workload"
+                  },
+                  "properties": [
+                     {
+                        "id": "links",
+                        "value": [
+                           {
+                              "title": "Drill down",
+                              "url": "/d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?${datasource:queryparam}&var-cluster=${cluster}&var-namespace=${namespace}&var-type=${__data.fields.Type}&var-workload=${__data.fields.Workload}"
+                           }
+                        ]
+                     }
+                  ]
+               }
+            ]
+         },
          "gridPos": {
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 10
+            "y": 9
          },
-         "id": 5,
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null as zero",
-         "renderer": "flot",
-         "scroll": true,
-         "showHeader": true,
-         "sort": {
-            "col": 0,
-            "desc": false
-         },
-         "spaceLength": 10,
-         "span": 24,
-         "styles": [
-            {
-               "alias": "Time",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Time",
-               "thresholds": [ ],
-               "type": "hidden",
-               "unit": "short"
-            },
-            {
-               "alias": "Current Bandwidth Received",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #A",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Current Bandwidth Transmitted",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #B",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Average Bandwidth Received",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #C",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Average Bandwidth Transmitted",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #D",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "Bps"
-            },
-            {
-               "alias": "Rate of Received Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #E",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #F",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Received Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #G",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Rate of Transmitted Packets Dropped",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": false,
-               "linkTooltip": "Drill down",
-               "linkUrl": "",
-               "pattern": "Value #H",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "pps"
-            },
-            {
-               "alias": "Workload",
-               "colorMode": null,
-               "colors": [ ],
-               "dateFormat": "YYYY-MM-DD HH:mm:ss",
-               "decimals": 2,
-               "link": true,
-               "linkTooltip": "Drill down",
-               "linkUrl": "d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell",
-               "pattern": "workload",
-               "thresholds": [ ],
-               "type": "number",
-               "unit": "short"
-            }
-         ],
+         "id": 3,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "B",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "C",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "D",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "E",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "F",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "G",
-               "step": 10
+               "instant": true
             },
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (namespace,pod) kube_pod_info{cluster=\"$cluster\",namespace=\"$namespace\",host_network=\"false\"}\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload, workload_type))\n",
                "format": "table",
-               "instant": true,
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "H",
-               "step": 10
+               "instant": true
             }
          ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Status",
+         "transformations": [
+            {
+               "id": "joinByField",
+               "options": {
+                  "byField": "workload",
+                  "mode": "outer"
+               }
+            },
+            {
+               "id": "organize",
+               "options": {
+                  "excludeByName": {
+                     "Time": true,
+                     "Time 1": true,
+                     "Time 2": true,
+                     "Time 3": true,
+                     "Time 4": true,
+                     "Time 5": true,
+                     "Time 6": true,
+                     "Time 7": true,
+                     "Time 8": true,
+                     "workload_type 2": true,
+                     "workload_type 3": true,
+                     "workload_type 4": true,
+                     "workload_type 5": true,
+                     "workload_type 6": true,
+                     "workload_type 7": true,
+                     "workload_type 8": true
+                  },
+                  "indexByName": {
+                     "Time 1": 0,
+                     "Time 2": 1,
+                     "Time 3": 2,
+                     "Time 4": 3,
+                     "Time 5": 4,
+                     "Time 6": 5,
+                     "Time 7": 6,
+                     "Time 8": 7,
+                     "Value #A": 10,
+                     "Value #B": 11,
+                     "Value #C": 12,
+                     "Value #D": 13,
+                     "Value #E": 14,
+                     "Value #F": 15,
+                     "Value #G": 16,
+                     "Value #H": 17,
+                     "workload": 8,
+                     "workload_type 1": 9,
+                     "workload_type 2": 18,
+                     "workload_type 3": 19,
+                     "workload_type 4": 20,
+                     "workload_type 5": 21,
+                     "workload_type 6": 22,
+                     "workload_type 7": 23,
+                     "workload_type 8": 24
+                  },
+                  "renameByName": {
+                     "Value #A": "Rx Bytes",
+                     "Value #B": "Tx Bytes",
+                     "Value #C": "Rx Bytes (Avg)",
+                     "Value #D": "Tx Bytes (Avg)",
+                     "Value #E": "Rx Packets",
+                     "Value #F": "Tx Packets",
+                     "Value #G": "Rx Packets Dropped",
+                     "Value #H": "Tx Packets Dropped",
+                     "workload": "Workload",
+                     "workload_type 1": "Type"
+                  }
+               }
+            }
+         ],
          "type": "table"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 19
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 6,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 20
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "id": 7,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{ workload }}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Received",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 20
-               },
-               "id": 8,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{ workload }}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Transmitted",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "unit": "Bps"
             }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 29
          },
-         "id": 9,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth HIstory",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 18
          },
-         "id": 10,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{workload}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Receive Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 18
          },
-         "id": 11,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{workload}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Transmit Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 39
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 12,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 40
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{workload}}",
-                     "refId": "A",
-                     "step": 10
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 27
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 40
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 14,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{workload}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Packets",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Average Container Bandwidth by Workload: Received",
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 40
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 15,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 41
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "id": 16,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{workload}}",
-                     "refId": "A",
-                     "step": 10
-                  }
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 27
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 41
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 17,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{workload}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Errors",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Average Container Bandwidth by Workload: Transmitted",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 36
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 36
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 45
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 45
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) kube_pod_info{host_network=\"false\"}\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 18,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1345,169 +703,61 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
             "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          },
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
+               "selected": false,
                "text": "kube-system",
                "value": "kube-system"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "deployment",
-               "value": "deployment"
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "includeAll": true,
+            "label": "workload_type",
             "name": "type",
-            "options": [ ],
-            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\"}, workload_type)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "resolution",
-            "options": [
-               {
-                  "selected": false,
-                  "text": "30s",
-                  "value": "30s"
-               },
-               {
-                  "selected": true,
-                  "text": "5m",
-                  "value": "5m"
-               },
-               {
-                  "selected": false,
-                  "text": "1h",
-                  "value": "1h"
-               }
-            ],
-            "query": "30s,5m,1h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "interval",
-            "options": [
-               {
-                  "selected": true,
-                  "text": "4h",
-                  "value": "4h"
-               }
-            ],
-            "query": "4h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1515,33 +765,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Networking / Namespace (Workload)",
-   "uid": "bbb2a765a623ae38130206c7d94a160f",
-   "version": 0
+   "uid": "bbb2a765a623ae38130206c7d94a160f"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/persistentvolumesusage.json
+++ b/resources/mixins/kubernetes/generated/dashboards/persistentvolumesusage.json
@@ -1,392 +1,233 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 9,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "Used Space",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "Free Space",
-                     "refId": "B"
-                  }
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 18,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Volume Space Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
+               "legendFormat": "Used Space"
             },
             {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "rgba(50, 172, 45, 0.97)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(245, 54, 54, 0.9)"
-               ],
-               "datasource": "$datasource",
-               "format": "percent",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": true,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "gridPos": { },
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 3,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "max without(instance,node) (\n(\n  topk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  topk(1, kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n/\ntopk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "80, 90",
-               "title": "Volume Space Usage",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "current"
+               "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
+               "legendFormat": "Free Space"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Volume Space Usage",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 80
+                     },
+                     {
+                        "color": "red",
+                        "value": 90
+                     }
+                  ]
+               },
+               "unit": "percent"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": true,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 9,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "Used inodes",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": " Free inodes",
-                     "refId": "B"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Volume inodes Usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "rgba(50, 172, 45, 0.97)",
-                  "rgba(237, 129, 40, 0.89)",
-                  "rgba(245, 54, 54, 0.9)"
-               ],
-               "datasource": "$datasource",
-               "format": "percent",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": true,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
-               },
-               "gridPos": { },
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 3,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "max without(instance,node) (\ntopk(1, kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n/\ntopk(1, kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "80, 90",
-               "title": "Volume inodes Usage",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "current"
+               "expr": "max without(instance,node) (\n(\n  topk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  topk(1, kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n/\ntopk(1, kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Volume Space Usage",
+         "type": "gauge"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 18,
+            "y": 7
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))",
+               "legendFormat": "Used inodes"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "(\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n  -\n  sum without(instance, node) (topk(1, (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})))\n)\n",
+               "legendFormat": "Free inodes"
+            }
+         ],
+         "title": "Volume inodes Usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "mode": "thresholds"
+               },
+               "max": 100,
+               "min": 0,
+               "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                     {
+                        "color": "green",
+                        "value": 0
+                     },
+                     {
+                        "color": "orange",
+                        "value": 80
+                     },
+                     {
+                        "color": "red",
+                        "value": 90
+                     }
+                  ]
+               },
+               "unit": "percent"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 18,
+            "y": 7
+         },
+         "id": 4,
+         "interval": "1m",
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "max without(instance,node) (\ntopk(1, kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n/\ntopk(1, kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n* 100)\n",
+               "instant": true
+            }
+         ],
+         "title": "Volume inodes Usage",
+         "type": "gauge"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -394,111 +235,63 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
-            "includeAll": false,
             "label": "Namespace",
-            "multi": false,
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\"}, namespace)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
-            "includeAll": false,
             "label": "PersistentVolumeClaim",
-            "multi": false,
             "name": "volume",
-            "options": [ ],
             "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\"}, persistentvolumeclaim)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
    "time": {
-      "from": "now-7d",
+      "from": "now-1h",
       "to": "now"
-   },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
    },
    "timezone": "UTC",
    "title": "Kubernetes / Persistent Volumes",
-   "uid": "919b92a8e8041bd567af9edab12c840c",
-   "version": 0
+   "uid": "919b92a8e8041bd567af9edab12c840c"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/pod-total.json
+++ b/resources/mixins/kubernetes/generated/dashboards/pod-total.json
@@ -1,897 +1,391 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [
-         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-         }
-      ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "editable": false,
    "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "displayName": "$pod",
+               "max": 10000000000,
+               "min": 0,
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "dark-green",
+                        "index": 0,
+                        "value": null
+                     },
+                     {
+                        "color": "dark-yellow",
+                        "index": 1,
+                        "value": 5000000000
+                     },
+                     {
+                        "color": "dark-red",
+                        "index": 2,
+                        "value": 7000000000
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Current Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "$datasource",
-         "decimals": 0,
-         "format": "time_series",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-         },
-         "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 1
-         },
-         "height": 9,
-         "id": 3,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "options": {
-            "fieldOptions": {
-               "calcs": [
-                  "last"
-               ],
-               "defaults": {
-                  "max": 10000000000,
-                  "min": 0,
-                  "title": "$namespace: $pod",
-                  "unit": "Bps"
-               },
-               "mappings": [ ],
-               "override": { },
-               "thresholds": [
-                  {
-                     "color": "dark-green",
-                     "index": 0,
-                     "value": null
-                  },
-                  {
-                     "color": "dark-yellow",
-                     "index": 1,
-                     "value": 5000000000
-                  },
-                  {
-                     "color": "dark-red",
-                     "index": 2,
-                     "value": 7000000000
-                  }
-               ],
-               "values": false
-            }
-         },
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "span": 12,
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
+         "id": 1,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
-               "format": "time_series",
-               "instant": null,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": "",
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Received",
-         "type": "gauge",
-         "valueFontSize": "80%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
+         "type": "gauge"
       },
       {
-         "cacheTimeout": null,
-         "colorBackground": false,
-         "colorValue": false,
-         "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-         ],
-         "datasource": "$datasource",
-         "decimals": 0,
-         "format": "time_series",
-         "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "displayName": "$pod",
+               "max": 10000000000,
+               "min": 0,
+               "thresholds": {
+                  "steps": [
+                     {
+                        "color": "dark-green",
+                        "index": 0,
+                        "value": null
+                     },
+                     {
+                        "color": "dark-yellow",
+                        "index": 1,
+                        "value": 5000000000
+                     },
+                     {
+                        "color": "dark-red",
+                        "index": 2,
+                        "value": 7000000000
+                     }
+                  ]
+               },
+               "unit": "Bps"
+            }
          },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 0
          },
-         "height": 9,
-         "id": 4,
-         "interval": null,
-         "links": [ ],
-         "mappingType": 1,
-         "mappingTypes": [
-            {
-               "name": "value to text",
-               "value": 1
-            },
-            {
-               "name": "range to text",
-               "value": 2
-            }
-         ],
-         "maxDataPoints": 100,
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "nullText": null,
-         "options": {
-            "fieldOptions": {
-               "calcs": [
-                  "last"
-               ],
-               "defaults": {
-                  "max": 10000000000,
-                  "min": 0,
-                  "title": "$namespace: $pod",
-                  "unit": "Bps"
-               },
-               "mappings": [ ],
-               "override": { },
-               "thresholds": [
-                  {
-                     "color": "dark-green",
-                     "index": 0,
-                     "value": null
-                  },
-                  {
-                     "color": "dark-yellow",
-                     "index": 1,
-                     "value": 5000000000
-                  },
-                  {
-                     "color": "dark-red",
-                     "index": 2,
-                     "value": 7000000000
-                  }
-               ],
-               "values": false
-            }
-         },
-         "postfix": "",
-         "postfixFontSize": "50%",
-         "prefix": "",
-         "prefixFontSize": "50%",
-         "rangeMaps": [
-            {
-               "from": "null",
-               "text": "N/A",
-               "to": "null"
-            }
-         ],
-         "span": 12,
-         "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-         },
-         "tableColumn": "",
+         "id": 2,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
-               "format": "time_series",
-               "instant": null,
-               "intervalFactor": 1,
-               "legendFormat": "",
-               "refId": "A"
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": "",
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Current Rate of Bytes Transmitted",
-         "type": "gauge",
-         "valueFontSize": "80%",
-         "valueMaps": [
-            {
-               "op": "=",
-               "text": "N/A",
-               "value": "null"
-            }
-         ],
-         "valueName": "current"
+         "type": "gauge"
       },
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 10
+            "y": 9
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Receive Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "binBps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 9
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Transmit Bandwidth",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 18
          },
          "id": 5,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 9,
-            "w": 12,
-            "x": 0,
-            "y": 11
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "id": 6,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Receive Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 18
          },
-         "id": 7,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Transmit Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
-            "y": 20
+            "y": 27
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "showPoints": "never"
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 27
          },
          "id": 8,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 0,
-                  "y": 21
-               },
-               "id": 9,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 12,
-                  "y": 21
-               },
-               "id": 10,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+            "tooltip": {
+               "mode": "single"
             }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Packets",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 21
          },
-         "id": 11,
-         "panels": [
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 0,
-                  "y": 32
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 12,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 10,
-                  "w": 12,
-                  "x": 12,
-                  "y": 32
-               },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Errors",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 18,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -899,169 +393,67 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\"}, cluster)",
             "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          },
          {
             "allValue": ".+",
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
+               "selected": false,
                "text": "kube-system",
                "value": "kube-system"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
             "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": ".+",
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
-               "text": "",
-               "value": ""
+               "selected": false,
+               "text": "kube-system",
+               "value": "kube-system"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "pod",
             "name": "pod",
-            "options": [ ],
             "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "resolution",
-            "options": [
-               {
-                  "selected": false,
-                  "text": "30s",
-                  "value": "30s"
-               },
-               {
-                  "selected": true,
-                  "text": "5m",
-                  "value": "5m"
-               },
-               {
-                  "selected": false,
-                  "text": "1h",
-                  "value": "1h"
-               }
-            ],
-            "query": "30s,5m,1h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "interval",
-            "options": [
-               {
-                  "selected": true,
-                  "text": "4h",
-                  "value": "4h"
-               }
-            ],
-            "query": "4h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1069,33 +461,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Networking / Pod",
-   "uid": "7a18067ce943a40ae25454675c19ff5c",
-   "version": 0
+   "uid": "7a18067ce943a40ae25454675c19ff5c"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/proxy.json
+++ b/resources/mixins/kubernetes/generated/dashboards/proxy.json
@@ -1,1010 +1,578 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "format": "none",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "gridPos": { },
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 2,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "sum(up{cluster=\"$cluster\", job=\"machine-config-daemon\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Up",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "min"
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 5,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "rate",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rules Sync Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 5,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rule Sync Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(up{cluster=\"$cluster\", job=\"machine-config-daemon\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Up",
+         "type": "stat"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "rate",
-                     "refId": "A"
-                  }
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 4,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Network Programming Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 6,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m])) by (instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Network Programming Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+               "legendFormat": "rate"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rules Sync Rate",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "2xx",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "3xx",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "4xx",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "5xx",
-                     "refId": "D"
-                  }
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 14,
+            "y": 0
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Kube API Request Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 8,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\",verb=\"POST\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Post Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+               "legendFormat": "{{instance}}"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rules Sync Latency 99th Quantile",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 7
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Get Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m]))",
+               "legendFormat": "rate"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Network Programming Rate",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 7
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 11,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 12,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\"}[5m])) by (instance, le))",
+               "legendFormat": "{{instance}}"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Network Programming Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 14
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+               "legendFormat": "2xx"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+               "legendFormat": "3xx"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+               "legendFormat": "4xx"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"machine-config-daemon\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+               "legendFormat": "5xx"
+            }
+         ],
+         "title": "Kube API Request Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 14
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\",verb=\"POST\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Post Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 21
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"machine-config-daemon\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Get Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 28
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Memory",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 28
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}[5m])",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "CPU usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 28
+         },
+         "id": 11,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "go_goroutines{cluster=\"$cluster\", job=\"machine-config-daemon\",instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Goroutines",
+         "type": "timeseries"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1012,57 +580,43 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"machine-config-daemon\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "allValue": ".+",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "instance",
             "name": "instance",
-            "options": [ ],
             "query": "label_values(up{job=\"machine-config-daemon\", cluster=\"$cluster\", job=\"machine-config-daemon\"}, instance)",
             "refresh": 2,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1070,33 +624,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Proxy",
-   "uid": "632e265de029684c40b21cb76bca4f94",
-   "version": 0
+   "uid": "632e265de029684c40b21cb76bca4f94"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/scheduler.json
+++ b/resources/mixins/kubernetes/generated/dashboards/scheduler.json
@@ -1,875 +1,524 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [ ]
-   },
    "editable": false,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
-   "refresh": "10s",
-   "rows": [
+   "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "unit": "none"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 4,
+            "x": 0,
+            "y": 0
+         },
+         "id": 1,
+         "interval": "1m",
+         "options": {
+            "colorMode": "none"
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "cacheTimeout": null,
-               "colorBackground": false,
-               "colorValue": false,
-               "colors": [
-                  "#299c46",
-                  "rgba(237, 129, 40, 0.89)",
-                  "#d44a3a"
-               ],
-               "datasource": "$datasource",
-               "format": "none",
-               "gauge": {
-                  "maxValue": 100,
-                  "minValue": 0,
-                  "show": false,
-                  "thresholdLabels": false,
-                  "thresholdMarkers": true
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "gridPos": { },
-               "id": 2,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "rightSide": true
-               },
-               "links": [ ],
-               "mappingType": 1,
-               "mappingTypes": [
-                  {
-                     "name": "value to text",
-                     "value": 1
-                  },
-                  {
-                     "name": "range to text",
-                     "value": 2
-                  }
-               ],
-               "maxDataPoints": 100,
-               "nullPointMode": "connected",
-               "nullText": null,
-               "postfix": "",
-               "postfixFontSize": "50%",
-               "prefix": "",
-               "prefixFontSize": "50%",
-               "rangeMaps": [
-                  {
-                     "from": "null",
-                     "text": "N/A",
-                     "to": "null"
-                  }
-               ],
-               "span": 2,
-               "sparkline": {
-                  "fillColor": "rgba(31, 118, 189, 0.18)",
-                  "full": false,
-                  "lineColor": "rgb(31, 120, 193)",
-                  "show": false
-               },
-               "tableColumn": "",
-               "targets": [
-                  {
-                     "expr": "sum(up{cluster=\"$cluster\", job=\"scheduler\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": "",
-               "title": "Up",
-               "tooltip": {
-                  "shared": false
-               },
-               "type": "singlestat",
-               "valueFontSize": "80%",
-               "valueMaps": [
-                  {
-                     "op": "=",
-                     "text": "N/A",
-                     "value": "null"
-                  }
-               ],
-               "valueName": "min"
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 3,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 5,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} e2e",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} binding",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} volume",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Scheduling Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 4,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 5,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} e2e",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} binding",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} scheduling algorithm",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{cluster}} {{instance}} volume",
-                     "refId": "D"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Scheduling latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(up{cluster=\"$cluster\", job=\"scheduler\"})",
+               "instant": true
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Up",
+         "type": "stat"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 5,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "2xx",
-                     "refId": "A"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "3xx",
-                     "refId": "B"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "4xx",
-                     "refId": "C"
-                  },
-                  {
-                     "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "5xx",
-                     "refId": "D"
-                  }
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 4,
+            "y": 0
+         },
+         "id": 2,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Kube API Request Rate",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "ops",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+               "legendFormat": "{{cluster}} {{instance}} e2e"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 6,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 8,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Post Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+               "legendFormat": "{{cluster}} {{instance}} binding"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+               "legendFormat": "{{cluster}} {{instance}} scheduling algorithm"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])) by (cluster, instance)",
+               "legendFormat": "{{cluster}} {{instance}} volume"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Scheduling Rate",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 7,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": true
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{verb}} {{url}}",
-                     "refId": "A"
-                  }
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 10,
+            "x": 14,
+            "y": 0
+         },
+         "id": 3,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Get Request Latency 99th Quantile",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
+               "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+               "legendFormat": "{{cluster}} {{instance}} e2e"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "yaxes": [
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+               "legendFormat": "{{cluster}} {{instance}} binding"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+               "legendFormat": "{{cluster}} {{instance}} scheduling algorithm"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}[5m])) by (cluster, instance, le))",
+               "legendFormat": "{{cluster}} {{instance}} volume"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Scheduling latency 99th Quantile",
+         "type": "timeseries"
       },
       {
-         "collapse": false,
-         "collapsed": false,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 8,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 7
+         },
+         "id": 4,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Memory",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+               "legendFormat": "2xx"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 9,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "CPU usage",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "bytes",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+               "legendFormat": "3xx"
             },
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 1,
-               "fillGradient": 0,
-               "gridPos": { },
-               "id": 10,
-               "interval": "1m",
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 4,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "go_goroutines{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{instance}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Goroutines",
-               "tooltip": {
-                  "shared": false,
-                  "sort": 0,
-                  "value_type": "individual"
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+               "legendFormat": "4xx"
+            },
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+               "legendFormat": "5xx"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": false,
-         "title": "Dashboard Row",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Kube API Request Rate",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "ops"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 16,
+            "x": 8,
+            "y": 7
+         },
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Post Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "s"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 14
+         },
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+               "legendFormat": "{{verb}} {{url}}"
+            }
+         ],
+         "title": "Get Request Latency 99th Quantile",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "bytes"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 21
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Memory",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 21
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"scheduler\", instance=~\"$instance\"}[5m])",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "CPU usage",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "short"
+            }
+         },
+         "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 21
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "go_goroutines{cluster=\"$cluster\", job=\"scheduler\",instance=~\"$instance\"}",
+               "legendFormat": "{{instance}}"
+            }
+         ],
+         "title": "Goroutines",
+         "type": "timeseries"
       }
    ],
-   "schemaVersion": 14,
-   "style": "dark",
+   "refresh": "10s",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -877,57 +526,43 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
             "label": "cluster",
-            "multi": false,
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(up{job=\"scheduler\"}, cluster)",
             "refresh": 2,
-            "regex": "",
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "allValue": ".+",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "instance",
             "name": "instance",
-            "options": [ ],
             "query": "label_values(up{job=\"scheduler\", cluster=\"$cluster\"}, instance)",
             "refresh": 2,
-            "regex": "",
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -935,33 +570,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Scheduler",
-   "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
-   "version": 0
+   "uid": "2e6b6a3b4bddf1427b3a55aa1311c656"
 }

--- a/resources/mixins/kubernetes/generated/dashboards/workload-total.json
+++ b/resources/mixins/kubernetes/generated/dashboards/workload-total.json
@@ -1,1055 +1,471 @@
 {
-   "__inputs": [ ],
-   "__requires": [ ],
-   "annotations": {
-      "list": [
-         {
-            "builtIn": 1,
-            "datasource": "-- Grafana --",
-            "enable": true,
-            "hide": true,
-            "iconColor": "rgba(0, 211, 255, 1)",
-            "name": "Annotations & Alerts",
-            "type": "dashboard"
-         }
-      ]
-   },
-   "editable": true,
-   "gnetId": null,
-   "graphTooltip": 0,
-   "hideControls": false,
-   "id": null,
-   "links": [ ],
+   "editable": false,
    "panels": [
       {
-         "collapse": false,
-         "collapsed": false,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
-            "h": 1,
-            "w": 24,
+            "h": 9,
+            "w": 12,
             "x": 0,
             "y": 0
          },
-         "id": 2,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Current Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
+         "id": 1,
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Current Rate of Bytes Received",
+         "type": "bargauge"
       },
       {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 0
+         },
+         "id": 2,
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Current Rate of Bytes Transmitted",
+         "type": "bargauge"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 9
          },
          "id": 3,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
          },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{ pod }}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(avg(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Current Rate of Bytes Received",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "title": "Average Rate of Bytes Received",
+         "type": "bargauge"
       },
       {
-         "aliasColors": { },
-         "bars": true,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "color": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+               },
+               "unit": "Bps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 9
          },
          "id": 4,
-         "legend": {
-            "alignAsTable": true,
-            "avg": false,
-            "current": true,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": true
+         "options": {
+            "displayMode": "basic",
+            "showUnfilled": false
          },
-         "lines": false,
-         "linewidth": 1,
-         "links": [ ],
-         "minSpan": 24,
-         "nullPointMode": "null",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 24,
-         "stack": false,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{ pod }}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(avg(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Current Rate of Bytes Transmitted",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
+         "title": "Average Rate of Bytes Transmitted",
+         "type": "bargauge"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "series",
-            "name": null,
-            "show": false,
-            "values": [
-               "current"
-            ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "binBps"
             }
-         ]
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 10
          },
-         "id": 5,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 11
-               },
-               "id": 6,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{ pod }}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Received",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": true,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 11
-               },
-               "id": 7,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": true,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": false,
-               "linewidth": 1,
-               "links": [ ],
-               "minSpan": 24,
-               "nullPointMode": "null",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 24,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{ pod }}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Average Rate of Bytes Transmitted",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "series",
-                  "name": null,
-                  "show": false,
-                  "values": [
-                     "current"
-                  ]
-               },
-               "yaxes": [
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "Bps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Average Bandwidth",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": false,
-         "collapsed": false,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 11
-         },
-         "id": 8,
-         "panels": [ ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Bandwidth HIstory",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 18
          },
-         "id": 9,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 5,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Receive Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$datasource",
-         "fill": 2,
-         "fillGradient": 0,
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "binBps"
+            }
+         },
          "gridPos": {
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 18
          },
-         "id": 10,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "hideEmpty": true,
-            "hideZero": true,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
+         "id": 6,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
          },
-         "lines": true,
-         "linewidth": 2,
-         "links": [ ],
-         "minSpan": 12,
-         "nullPointMode": "connected",
-         "paceLength": 10,
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 12,
-         "stack": true,
-         "steppedLine": false,
+         "pluginVersion": "v11.0.0",
          "targets": [
             {
-               "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-               "format": "time_series",
-               "intervalFactor": 1,
-               "legendFormat": "{{pod}}",
-               "refId": "A",
-               "step": 10
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_bytes_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
          "title": "Transmit Bandwidth",
-         "tooltip": {
-            "shared": true,
-            "sort": 2,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            },
-            {
-               "format": "Bps",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": 0,
-               "show": true
-            }
-         ]
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 21
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 11,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 22
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "id": 12,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 27
+         },
+         "id": 7,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 22
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 13,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Packets",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of Received Packets",
+         "type": "timeseries"
       },
       {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 22
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
          },
-         "id": 14,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 0,
-                  "y": 23
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
                },
-               "id": 15,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 27
+         },
+         "id": 8,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
                ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Received Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
             },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$datasource",
-               "fill": 2,
-               "fillGradient": 0,
-               "gridPos": {
-                  "h": 9,
-                  "w": 12,
-                  "x": 12,
-                  "y": 23
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
                },
-               "id": 16,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "hideEmpty": true,
-                  "hideZero": true,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 2,
-               "links": [ ],
-               "minSpan": 12,
-               "nullPointMode": "connected",
-               "paceLength": 10,
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "span": 12,
-               "stack": true,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
-                     "format": "time_series",
-                     "intervalFactor": 1,
-                     "legendFormat": "{{pod}}",
-                     "refId": "A",
-                     "step": 10
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Rate of Transmitted Packets Dropped",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "format": "pps",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
             }
          ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Errors",
-         "titleSize": "h6",
-         "type": "row"
+         "title": "Rate of Transmitted Packets",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 36
+         },
+         "id": 9,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_receive_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Received Packets Dropped",
+         "type": "timeseries"
+      },
+      {
+         "datasource": {
+            "type": "datasource",
+            "uid": "-- Mixed --"
+         },
+         "fieldConfig": {
+            "defaults": {
+               "custom": {
+                  "fillOpacity": 10,
+                  "showPoints": "never",
+                  "spanNulls": true
+               },
+               "unit": "pps"
+            }
+         },
+         "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 36
+         },
+         "id": 10,
+         "interval": "1m",
+         "options": {
+            "legend": {
+               "asTable": true,
+               "calcs": [
+                  "lastNotNull"
+               ],
+               "displayMode": "table",
+               "placement": "right",
+               "showLegend": true
+            },
+            "tooltip": {
+               "mode": "single"
+            }
+         },
+         "pluginVersion": "v11.0.0",
+         "targets": [
+            {
+               "datasource": {
+                  "type": "prometheus",
+                  "uid": "${datasource}"
+               },
+               "expr": "sort_desc(sum(rate(container_network_transmit_packets_dropped_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+               "legendFormat": "__auto"
+            }
+         ],
+         "title": "Rate of Transmitted Packets Dropped",
+         "type": "timeseries"
       }
    ],
    "refresh": "10s",
-   "rows": [ ],
-   "schemaVersion": 18,
-   "style": "dark",
+   "schemaVersion": 39,
    "tags": [
       "kubernetes-mixin"
    ],
@@ -1057,197 +473,77 @@
       "list": [
          {
             "current": {
+               "selected": true,
                "text": "default",
                "value": "default"
             },
             "hide": 0,
-            "label": "Data Source",
+            "label": "Data source",
             "name": "datasource",
-            "options": [ ],
             "query": "prometheus",
-            "refresh": 1,
             "regex": "",
             "type": "datasource"
          },
          {
-            "allValue": null,
-            "current": { },
-            "datasource": "$datasource",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "cluster",
             "name": "cluster",
-            "options": [ ],
             "query": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster)",
             "refresh": 2,
-            "regex": "",
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "sort": 1,
+            "type": "query"
          },
          {
             "allValue": ".+",
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
             "current": {
+               "selected": false,
                "text": "kube-system",
                "value": "kube-system"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\"}, namespace)",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
+            },
             "hide": 0,
             "includeAll": true,
-            "label": null,
-            "multi": false,
+            "label": "namespace",
             "name": "namespace",
-            "options": [ ],
-            "query": "label_values(container_network_receive_packets_total{job=\"kubelet\",metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\"}, namespace)",
+            "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "",
-               "value": ""
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "label": "workload",
             "name": "workload",
-            "options": [ ],
-            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\"}, workload)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
+            "type": "query"
          },
          {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "deployment",
-               "value": "deployment"
+            "allValue": ".+",
+            "datasource": {
+               "type": "prometheus",
+               "uid": "${datasource}"
             },
-            "datasource": "$datasource",
-            "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
             "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
+            "includeAll": true,
+            "label": "workload_type",
             "name": "type",
-            "options": [ ],
-            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
+            "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
             "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 0,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "query",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "resolution",
-            "options": [
-               {
-                  "selected": false,
-                  "text": "30s",
-                  "value": "30s"
-               },
-               {
-                  "selected": true,
-                  "text": "5m",
-                  "value": "5m"
-               },
-               {
-                  "selected": false,
-                  "text": "1h",
-                  "value": "1h"
-               }
-            ],
-            "query": "30s,5m,1h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
             "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
-         },
-         {
-            "allValue": null,
-            "auto": false,
-            "auto_count": 30,
-            "auto_min": "10s",
-            "current": {
-               "text": "5m",
-               "value": "5m"
-            },
-            "datasource": "$datasource",
-            "hide": 2,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "interval",
-            "options": [
-               {
-                  "selected": true,
-                  "text": "4h",
-                  "value": "4h"
-               }
-            ],
-            "query": "4h",
-            "refresh": 2,
-            "regex": "",
-            "skipUrlSync": false,
-            "sort": 1,
-            "tagValuesQuery": "",
-            "tags": [ ],
-            "tagsQuery": "",
-            "type": "interval",
-            "useTags": false
+            "type": "query"
          }
       ]
    },
@@ -1255,33 +551,7 @@
       "from": "now-1h",
       "to": "now"
    },
-   "timepicker": {
-      "refresh_intervals": [
-         "5s",
-         "10s",
-         "30s",
-         "1m",
-         "5m",
-         "15m",
-         "30m",
-         "1h",
-         "2h",
-         "1d"
-      ],
-      "time_options": [
-         "5m",
-         "15m",
-         "1h",
-         "6h",
-         "12h",
-         "24h",
-         "2d",
-         "7d",
-         "30d"
-      ]
-   },
    "timezone": "UTC",
    "title": "Kubernetes / Networking / Workload",
-   "uid": "728bf77cc1166d2f3133bf25846876cc",
-   "version": 0
+   "uid": "728bf77cc1166d2f3133bf25846876cc"
 }

--- a/resources/mixins/kubernetes/jsonnetfile.lock.json
+++ b/resources/mixins/kubernetes/jsonnetfile.lock.json
@@ -14,12 +14,52 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-latest"
+        }
+      },
+      "version": "119d65363dff84a1976bba609f2ac3a8f450e760",
+      "sum": "eyuJ0jOXeA4MrobbNgU4/v5a7ASDHslHZ0eS6hDdWoI="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/grafana/grafonnet.git",
+          "subdir": "gen/grafonnet-v11.0.0"
+        }
+      },
+      "version": "119d65363dff84a1976bba609f2ac3a8f450e760",
+      "sum": "Fuo+qTZZzF+sHDBWX/8fkPsUmwW6qhH8hRVz45HznfI="
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/grafana/jsonnet-libs.git",
           "subdir": "grafana-builder"
         }
       },
-      "version": "672dec488b8126ba10b80f221a876735bcda2549",
-      "sum": "xEFMv4+ObwP5L1Wu0XK5agWci4AJzNApys6iKAQxLlQ="
+      "version": "02db06f540086fa3f67d487bd01e1b314853fb8f",
+      "sum": "B49EzIY2WZsFxNMJcgRxE/gcZ9ltnS8pkOOV6Q5qioc="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": "doc-util"
+        }
+      },
+      "version": "6ac6c69685b8c29c54515448eaca583da2d88150",
+      "sum": "BrAL/k23jq+xy9oA7TWIhUx07dsA/QLm3g7ktCwe//U="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/xtd.git",
+          "subdir": ""
+        }
+      },
+      "version": "63d430b69a95741061c2f7fc9d84b1a778511d9c",
+      "sum": "qiZi3axUSXCVzKUF83zSAxklwrnitMmrDK4XAfjPMdE="
     },
     {
       "source": {
@@ -28,8 +68,8 @@
           "subdir": ""
         }
       },
-      "version": "46fc905d5b2981642043088ac7902ea50db2903e",
-      "sum": "8FAie1MXww5Ip9F8hQWkU9Fio1Af+hO4weQuuexioIQ="
+      "version": "de834e9a291b49396125768f041e2078763f48b5",
+      "sum": "E6z1j4MS6/NnIVZkUuk+gb0m9FvRmZ77H6SSopIZEa8="
     }
   ],
   "legacyImports": false

--- a/resources/prometheus/federation-config.yaml
+++ b/resources/prometheus/federation-config.yaml
@@ -26,7 +26,7 @@ match[]:
   - cluster_autoscaler_skipped_scale_events_count{job!~"central|scanner"}
   - cluster_autoscaler_unneeded_nodes_count{job!~"central|scanner"}
   - cluster_autoscaler_unschedulable_pods_count{job!~"central|scanner"}
-  - cluster_quantile:apiserver_request_slo_duration_seconds:histogram_quantile{job!~"central|scanner"}
+  - cluster_quantile:apiserver_request_sli_duration_seconds:histogram_quantile{job!~"central|scanner"}
   - code_resource:apiserver_request_total:rate5m{job!~"central|scanner"}
   - container_cpu_cfs_periods_total{job!~"central|scanner"}
   - container_cpu_cfs_throttled_periods_total{job!~"central|scanner"}
@@ -118,9 +118,7 @@ match[]:
   - kubelet_pod_start_duration_seconds_count{job!~"central|scanner"}
   - kubelet_pod_worker_duration_seconds_bucket{job!~"central|scanner"}
   - kubelet_pod_worker_duration_seconds_count{job!~"central|scanner"}
-  - kubelet_running_container_count{job!~"central|scanner"}
   - kubelet_running_containers{job!~"central|scanner"}
-  - kubelet_running_pod_count{job!~"central|scanner"}
   - kubelet_running_pods{job!~"central|scanner"}
   - kubelet_runtime_operations_duration_seconds_bucket{job!~"central|scanner"}
   - kubelet_runtime_operations_errors_total{job!~"central|scanner"}

--- a/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
@@ -370,9 +370,9 @@ spec:
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh"
             "summary": "Processes experience elevated CPU throttling."
           "expr": |
-            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"openshift-.*"}[5m])) by (cluster, container, pod, namespace)
               /
-            sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_periods_total{namespace!~"openshift-.*"}[5m])) by (cluster, container, pod, namespace)
               > ( 25 / 100 )
           "for": "15m"
           "labels":
@@ -382,7 +382,7 @@ spec:
       "rules":
         - "alert": "KubePersistentVolumeFillingUp"
           "annotations":
-            "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free."
+            "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is only {{ $value | humanizePercentage }} free."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup"
             "summary": "PersistentVolume is filling up."
           "expr": |
@@ -393,9 +393,9 @@ spec:
             ) < 0.03
             and
             kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
@@ -403,7 +403,7 @@ spec:
             "source": "mixin/kubernetes"
         - "alert": "KubePersistentVolumeFillingUp"
           "annotations":
-            "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available."
+            "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup"
             "summary": "PersistentVolume is filling up."
           "expr": |
@@ -416,9 +416,9 @@ spec:
             kubelet_volume_stats_used_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
             and
             predict_linear(kubelet_volume_stats_available_bytes{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
@@ -426,7 +426,7 @@ spec:
             "source": "mixin/kubernetes"
         - "alert": "KubePersistentVolumeInodesFillingUp"
           "annotations":
-            "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} only has {{ $value | humanizePercentage }} free inodes."
+            "description": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} only has {{ $value | humanizePercentage }} free inodes."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup"
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
@@ -437,9 +437,9 @@ spec:
             ) < 0.03
             and
             kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1m"
           "labels":
@@ -447,7 +447,7 @@ spec:
             "source": "mixin/kubernetes"
         - "alert": "KubePersistentVolumeInodesFillingUp"
           "annotations":
-            "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free."
+            "description": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeinodesfillingup"
             "summary": "PersistentVolumeInodes are filling up."
           "expr": |
@@ -460,9 +460,9 @@ spec:
             kubelet_volume_stats_inodes_used{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"} > 0
             and
             predict_linear(kubelet_volume_stats_inodes_free{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",job="kubelet"}[6h], 4 * 24 * 3600) < 0
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
-            unless on(namespace, persistentvolumeclaim)
+            unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
           "for": "1h"
           "labels":
@@ -470,7 +470,7 @@ spec:
             "source": "mixin/kubernetes"
         - "alert": "KubePersistentVolumeErrors"
           "annotations":
-            "description": "The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}."
+            "description": "The persistent volume {{ $labels.persistentvolume }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} has status {{ $labels.phase }}."
             "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors"
             "summary": "PersistentVolume is having issues with provisioning."
           "expr": |


### PR DESCRIPTION
I've ran a `make update` to bump the mixin version. The current version still generates old Grafana widgets that produce deprecation warnings, hopefully the updated ones fix that.