### PR TITLE
fix: branch sync workflow

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_METHOD: merge
-          MERGE_FILTER_AUTHOR: github-actions
+          MERGE_FILTER_AUTHOR: github-actions[bot]

--- a/.github/workflows/sync-prod-from-stage.yaml
+++ b/.github/workflows/sync-prod-from-stage.yaml
@@ -1,6 +1,11 @@
 name: Sync stage -> production
 on:
   workflow_dispatch:
+permissions:
+  # Needed to read branches.
+  contents: read
+  # Needed to create PR's.
+  pull-requests: write
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
@@ -8,12 +13,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Opening pull request
         id: pull
-        # Need master for LABELS option.
-        uses: tretuna/sync-branches@master
+        uses: jdtx0/branch-sync@v1.5.1
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "stage"
           TO_BRANCH: "production"
           LABELS: '["automerge"]'
+          PULL_REQUEST_AUTO_MERGE_METHOD: "merge"

--- a/.github/workflows/sync-stage-from-master.yaml
+++ b/.github/workflows/sync-stage-from-master.yaml
@@ -1,6 +1,11 @@
 name: Sync master -> stage
 on:
   workflow_dispatch:
+permissions:
+  # Needed to read branches.
+  contents: read
+  # Needed to create PR's.
+  pull-requests: write
 jobs:
   sync-branches:
     runs-on: ubuntu-latest
@@ -8,12 +13,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Opening pull request
         id: pull
-        # Need master for LABELS option.
-        uses: tretuna/sync-branches@master
+        uses: jdtx0/branch-sync@v1.5.1
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "master"
           TO_BRANCH: "stage"
           LABELS: '["automerge"]'
+          PULL_REQUEST_AUTO_MERGE_METHOD: "merge"


### PR DESCRIPTION
The `automerge` workflow currently does not work. This PR addresses the following problems with it:

* the current sync action is outdated and doesn't work properly (lables are not being set). I've updated to a maintained fork.
* the author filter in the automerge workflow is missing the `[bot]` suffix.