### PR TITLE
Revert "chore: add more automerge options"

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -31,6 +31,3 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_METHOD: merge
           MERGE_FILTER_AUTHOR: github-actions[bot]
-          MERGE_FORKS: false
-          MERGE_REQUIRED_APPROVALS: 1
-          UPDATE_METHOD: rebase


### PR DESCRIPTION
Ok this broke the automerge action again :( (see https://github.com/stackrox/rhacs-observability-resources/pull/263). Let's just revert it and let it be as it was.

Reverts stackrox/rhacs-observability-resources#262