### PR TITLE
Add missing containers to "Container Restarts" graph

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-central.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-central.yaml
@@ -522,6 +522,7 @@ spec:
                     "axisPlacement": "auto",
                     "barAlignment": 0,
                     "drawStyle": "line",
+                    "axisBorderShow": false,
                     "fillOpacity": 10,
                     "gradientMode": "none",
                     "hideFrom": {
@@ -531,6 +532,7 @@ spec:
                     },
                     "lineInterpolation": "stepAfter",
                     "lineWidth": 1,
+                    "insertNulls": false,
                     "pointSize": 5,
                     "scaleDistribution": {
                       "type": "linear"
@@ -583,7 +585,6 @@ spec:
                 "y": 7
               },
               "id": 110,
-              "links": [],
               "options": {
                 "legend": {
                   "calcs": [],
@@ -622,6 +623,62 @@ spec:
                   "legendFormat": "scanner",
                   "range": true,
                   "refId": "B"
+                },
+                {
+                  "datasource": {
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"db\", pod=~\"scanner-db-.*\", job=~\"kube-state-metrics\"}[5m]))",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "scanner-db",
+                  "range": true,
+                  "refId": "F"
+                },
+                {
+                  "datasource": {
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"matcher\", job=~\"kube-state-metrics\"}[5m]))",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "scanner-v4-matcher",
+                  "range": true,
+                  "refId": "C"
+                },
+                {
+                  "datasource": {
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"indexer\", job=~\"kube-state-metrics\"}[5m]))",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "scanner-v4-indexer",
+                  "range": true,
+                  "refId": "D"
+                },
+                {
+                  "datasource": {
+                    "uid": "${datasource}"
+                  },
+                  "editorMode": "code",
+                  "exemplar": true,
+                  "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"db\", pod=~\"scanner-v4-db-.*\", job=~\"kube-state-metrics\"}[5m]))",
+                  "hide": false,
+                  "interval": "",
+                  "intervalFactor": 2,
+                  "legendFormat": "scanner-v4-db",
+                  "range": true,
+                  "refId": "E"
                 }
               ],
               "title": "Container Restarts",

--- a/resources/grafana/sources/rhacs-central.json
+++ b/resources/grafana/sources/rhacs-central.json
@@ -512,6 +512,7 @@
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
+                "axisBorderShow": false,
                 "fillOpacity": 10,
                 "gradientMode": "none",
                 "hideFrom": {
@@ -521,6 +522,7 @@
                 },
                 "lineInterpolation": "stepAfter",
                 "lineWidth": 1,
+                "insertNulls": false,
                 "pointSize": 5,
                 "scaleDistribution": {
                   "type": "linear"
@@ -573,7 +575,6 @@
             "y": 7
           },
           "id": 110,
-          "links": [],
           "options": {
             "legend": {
               "calcs": [],
@@ -612,6 +613,62 @@
               "legendFormat": "scanner",
               "range": true,
               "refId": "B"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"db\", pod=~\"scanner-db-.*\", job=~\"kube-state-metrics\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "scanner-db",
+              "range": true,
+              "refId": "F"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"matcher\", job=~\"kube-state-metrics\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "scanner-v4-matcher",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"indexer\", job=~\"kube-state-metrics\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "scanner-v4-indexer",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"rhacs-$instance_id\", container=\"db\", pod=~\"scanner-v4-db-.*\", job=~\"kube-state-metrics\"}[5m]))",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "scanner-v4-db",
+              "range": true,
+              "refId": "E"
             }
           ],
           "title": "Container Restarts",


### PR DESCRIPTION
For investigation purposes it might be important to obtain an holistic view of container restarts within tenant namespaces, not only for central and scanner.

![Uploading image.png…]()
