### PR TITLE
ROX-21873: increase sensitivity on alert for tenant db connections

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -39,7 +39,7 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-003-rhacs-instance-unavailable.md"
         - alert: RHACSCentralPostgresConnectionDown
           expr: avg_over_time(rox_central_postgres_connected{container="central"}[10m]) < 0.5
-          for: 20m
+          for: 10m
           labels:
             severity: critical
           annotations:


### PR DESCRIPTION
I've tested this alert as part of https://issues.redhat.com/browse/ROX-21873 by blocking DB ingress via AWS security groups.

It took 35 minutes for this alert to appear in alertmanager. This is because we're working with the AVG metric in this alert and have a wait time of 20 minutes defined. Since a broken DB connection means a critical state for the entire system I think we should alert earlier on this.

Looking at the metrics for longer running tenants it seems to make sense to continue using the AVG because on central rollouts this metric might be down for some time. So instead of increasing the threshold I reduced the wait time to 10 minutes.

