### PR TITLE
Revert "ROX-21873: increase sensitivity on alert for tenant db connections"

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -39,7 +39,7 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-003-rhacs-instance-unavailable.md"
         - alert: RHACSCentralPostgresConnectionDown
           expr: avg_over_time(rox_central_postgres_connected{container="central"}[10m]) < 0.5
-          for: 10m
+          for: 20m
           labels:
             severity: critical
           annotations:


### PR DESCRIPTION
Reverts stackrox/rhacs-observability-resources#271

The alert has been firing for every probe instance since the change. The 10 mins seem to not be enough to take the provisioning time into account.

We need to revert before this is shipped to prod.
