### PR TITLE
FIX: Fix pre-commit CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: actions/setup-go@v5
         with:
           go-version: ">=1.18.0"


### PR DESCRIPTION
`pre-commit` CI step [fails](https://github.com/stackrox/rhacs-observability-resources/actions/runs/11294068645/job/31413669648?pr=281) with:
```
Run pre-commit/action@v3.0.1
Run python -m pip install pre-commit
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
 ```


GH actions uses `ubuntu-latest` and GH recently started to [migrate ubuntu version](https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/). The new ubuntu version comes with new python and pip. The new pip fails to install system wide packages by default to follow[ PEP-668](https://peps.python.org/pep-0668/). Technically it should not be an issue because this repo CI setups a dedicated python so it should be used to install pre-commit instead of default ubuntu python. The problem is that this setup python step do not do anything by default. Here are the logs:
```
Run actions/setup-python@v5
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Warning: .python-version doesn't exist.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.
```

This PR fixes it and make `setup-python` step prepare env for the `pre-commit` installation