### PR TITLE
ROX-27298: Add InfoInhibitor to the prometheus rules

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -406,6 +406,23 @@ spec:
             name: DeadMansSwitchAlert
             observability: managed-rhacs
 
+    - name: inhibit
+      rules:
+        - alert: InfoInhibitor
+          annotations:
+            description: |
+              This is an alert that is used to inhibit info alerts.
+              By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
+              other alerts.
+              This alert fires whenever there's a severity="info" alert, and stops firing when another alert with a
+              severity of 'warning' or 'critical' starts firing on the same namespace.
+              This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
+            sop_url: https://runbooks.prometheus-operator.dev/runbooks/general/infoinhibitor
+            summary: Info-level alert inhibition.
+          expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+          labels:
+            severity: none
+
     - name: federation
       rules:
         - alert: OpenshiftMonitoringFederationScrapeTargetDown

--- a/scripts/generate-federate-match.sh
+++ b/scripts/generate-federate-match.sh
@@ -81,7 +81,7 @@ function main() {
     done <<< "${rules_files}"
 
     # Filter metrics (exclude metrics that are collected by observability Prometheus or created by recording rules)
-    sort "${metrics_list_file}" | uniq | grep -v -E "^acs|^rox|^aws|^central:|acscs_worker_nodes|^probe" | awk '{ print $1 "{job!~\"central|scanner\"}" }' > "${metrics_list_file}.filter"
+    sort "${metrics_list_file}" | uniq | grep -v -E "^acs|^rox|^aws|^central:|acscs_worker_nodes|^probe|^ALERTS" | awk '{ print $1 "{job!~\"central|scanner\"}" }' > "${metrics_list_file}.filter"
     local yq_expression
     # shellcheck disable=SC2016
     # $f is not a shell variable, but a yq variable, so it should not be surrounded by double quotes


### PR DESCRIPTION
Add `InfoInhibitor` rule to inhibit info alerts unless other alerts fire in the same namespace