### PR TITLE
ROX-16860: Cover undefined availability metrics in Central SLOs

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -177,23 +177,23 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
         - alert: RHACSFleetshardSyncCentralCountPodMismatch
           expr: |
-            sum(acs_fleetshard_total_centrals) != count(central:sli:pod_ready)
-          for: 15m
+            sum(acs_fleetshard_ready_centrals) != count(central:sli:pod_ready)
+          for: 45m
           labels:
             severity: warning
           annotations:
-            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | first | value }} centrals while the central pod count is {{ query \"count(central:sli:pod_ready)\" | first | value }}."
-            description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
+            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_ready_centrals)\" | first | value }} centrals while the central pod count is {{ query \"count(central:sli:pod_ready)\" | first | value }}."
+            description: "For the last 45 minutes, the number of ready Centrals returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
         - alert: RHACSFleetshardSyncCentralCountHealthMismatch
           expr: |
-            sum(acs_fleetshard_total_centrals) != count(central:health)
-          for: 15m
+            sum(acs_fleetshard_ready_centrals) != count(central:health)
+          for: 45m
           labels:
             severity: warning
           annotations:
-            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | first | value }} centrals while the health of {{ query \"count(central:health)\" | first | value }} Centrals is checked."
-            description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
+            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_ready_centrals)\" | first | value }} centrals while the health of {{ query \"count(central:health)\" | first | value }} Centrals is checked."
+            description: "For the last 45 minutes, the number of ready Centrals returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"
 
     - name: rhacs-emailsender

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -192,7 +192,7 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | value }} centrals while the health of {{ query \"count(central:health)\" }} Centrals is checked."
+            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | first | value }} centrals while the health of {{ query \"count(central:health)\" | first | value }} Centrals is checked."
             description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"
 

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -175,6 +175,30 @@ spec:
             summary: "Fleetshard synchronizer manages `{{ $value }}` centrals."
             description: "Fleetshard synchronizer manages `{{ $value }}` centrals. The number of Centrals should always be larger than zero in a working system. If it drops to or below zero, fleetshard synchronizer is assumed to be in a failed state."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
+        - alert: RHACSFleetshardSyncCentralCountPodMismatch
+          expr: |
+            sum(acs_fleetshard_total_centrals) != count(central:sli:pod_ready)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: |
+              Fleetshard synchronizer manages {{ query "sum(acs_fleetshard_total_centrals)" }} centrals while the central pod count is {{ query "count(central:sli:pod_ready)" }}.
+            description: |
+              For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state.
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
+        - alert: RHACSFleetshardSyncCentralCountHealthMismatch
+          expr: |
+            sum(acs_fleetshard_total_centrals) != count(central:health)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: |
+              Fleetshard synchronizer manages {{ query "sum(acs_fleetshard_total_centrals)" }} centrals while the health of {{ query "count(central:health)" }} Centrals is checked.
+            description: |
+              For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status.
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"
 
     - name: rhacs-emailsender
       rules:

--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -182,10 +182,8 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: |
-              Fleetshard synchronizer manages {{ query "sum(acs_fleetshard_total_centrals)" }} centrals while the central pod count is {{ query "count(central:sli:pod_ready)" }}.
-            description: |
-              For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state.
+            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | first | value }} centrals while the central pod count is {{ query \"count(central:sli:pod_ready)\" | first | value }}."
+            description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
         - alert: RHACSFleetshardSyncCentralCountHealthMismatch
           expr: |
@@ -194,10 +192,8 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: |
-              Fleetshard synchronizer manages {{ query "sum(acs_fleetshard_total_centrals)" }} centrals while the health of {{ query "count(central:health)" }} Centrals is checked.
-            description: |
-              For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status.
+            summary: "Fleetshard synchronizer manages {{ query \"sum(acs_fleetshard_total_centrals)\" | value }} centrals while the health of {{ query \"count(central:health)\" }} Centrals is checked."
+            description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"
 
     - name: rhacs-emailsender

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountHealthMismatch.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountHealthMismatch.yaml
@@ -7,30 +7,30 @@ tests:
   # Test new instance created but pod doesn't exist
   - interval: 1m
     input_series:
-      - series: acs_fleetshard_total_centrals
-        values: "4x5 5x25"
+      - series: acs_fleetshard_ready_centrals
+        values: "4x15 5x60"
       - series: probe_success{app="rhacs", namespace="rhacs-co1cgv2hofac73cvpm5g", rhacs_instance_id="co1cgv2hofac73cvpm5g", endpoint="central-ui"}
-        values: "1x30"
+        values: "1x75"
       - series: probe_success{app="rhacs", namespace="rhacs-co1cgv2hofac73cvpm5g", rhacs_instance_id="co1cgv2hofac73cvpm5g", endpoint="central-data"}
-        values: "1x30"
+        values: "1x75"
       # Count unhealthy instances as well
       - series: probe_success{app="rhacs", namespace="rhacs-cq1636iqbcns73fiki8g", rhacs_instance_id="cq1636iqbcns73fiki8g", endpoint="central-ui"}
-        values: "0x30"
+        values: "0x75"
       - series: probe_success{app="rhacs", namespace="rhacs-cq1636iqbcns73fiki8g", rhacs_instance_id="cq1636iqbcns73fiki8g", endpoint="central-data"}
-        values: "0x30"
+        values: "0x75"
       - series: probe_success{app="rhacs", namespace="rhacs-cr2o56pjctnc739qmqv0", rhacs_instance_id="cr2o56pjctnc739qmqv0", endpoint="central-ui"}
-        values: "1x30"
+        values: "1x75"
       - series: probe_success{app="rhacs", namespace="rhacs-cr2o56pjctnc739qmqv0", rhacs_instance_id="cr2o56pjctnc739qmqv0", endpoint="central-data"}
-        values: "0x30"
+        values: "0x75"
       - series: probe_success{app="rhacs", namespace="rhacs-cu3nrb4qls9s73emtae0", rhacs_instance_id="cu3nrb4qls9s73emtae0", endpoint="central-ui"}
-        values: "0x30"
+        values: "0x75"
       - series: probe_success{app="rhacs", namespace="rhacs-cu3nrb4qls9s73emtae0", rhacs_instance_id="cu3nrb4qls9s73emtae0", endpoint="central-data"}
-        values: "1x30"
+        values: "1x75"
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 30m
         alertname: RHACSFleetshardSyncCentralCountHealthMismatch
         exp_alerts: []
-      - eval_time: 25m
+      - eval_time: 61m
         alertname: RHACSFleetshardSyncCentralCountHealthMismatch
         exp_alerts:
           - exp_labels:
@@ -38,5 +38,5 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Fleetshard synchronizer manages 5 centrals while the health of 4 Centrals is checked."
-              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
+              description: "For the last 45 minutes, the number of ready Centrals returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountHealthMismatch.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountHealthMismatch.yaml
@@ -1,0 +1,42 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Test new instance created but pod doesn't exist
+  - interval: 1m
+    input_series:
+      - series: acs_fleetshard_total_centrals
+        values: "4x5 5x25"
+      - series: probe_success{app="rhacs", namespace="rhacs-co1cgv2hofac73cvpm5g", rhacs_instance_id="co1cgv2hofac73cvpm5g", endpoint="central-ui"}
+        values: "1x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-co1cgv2hofac73cvpm5g", rhacs_instance_id="co1cgv2hofac73cvpm5g", endpoint="central-data"}
+        values: "1x30"
+      # Count unhealthy instances as well
+      - series: probe_success{app="rhacs", namespace="rhacs-cq1636iqbcns73fiki8g", rhacs_instance_id="cq1636iqbcns73fiki8g", endpoint="central-ui"}
+        values: "0x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-cq1636iqbcns73fiki8g", rhacs_instance_id="cq1636iqbcns73fiki8g", endpoint="central-data"}
+        values: "0x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-cr2o56pjctnc739qmqv0", rhacs_instance_id="cr2o56pjctnc739qmqv0", endpoint="central-ui"}
+        values: "1x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-cr2o56pjctnc739qmqv0", rhacs_instance_id="cr2o56pjctnc739qmqv0", endpoint="central-data"}
+        values: "0x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-cu3nrb4qls9s73emtae0", rhacs_instance_id="cu3nrb4qls9s73emtae0", endpoint="central-ui"}
+        values: "0x30"
+      - series: probe_success{app="rhacs", namespace="rhacs-cu3nrb4qls9s73emtae0", rhacs_instance_id="cu3nrb4qls9s73emtae0", endpoint="central-data"}
+        values: "1x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RHACSFleetshardSyncCentralCountHealthMismatch
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: RHACSFleetshardSyncCentralCountHealthMismatch
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSFleetshardSyncCentralCountHealthMismatch
+              severity: warning
+            exp_annotations:
+              summary: "Fleetshard synchronizer manages 5 centrals while the health of 4 Centrals is checked."
+              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Centrals, whose health is being checked. This may be an indication that the monitoring system is faulty and the Central SLI metrics may not match the actual status."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-052-central-healthcheck-issues.md"

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountPodMismatch.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountPodMismatch.yaml
@@ -7,20 +7,20 @@ tests:
   # Test new instance created but pod doesn't exist
   - interval: 1m
     input_series:
-      - series: acs_fleetshard_total_centrals
-        values: "3x5 4x25"
+      - series: acs_fleetshard_ready_centrals
+        values: "3x15 4x60"
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-co1cgv2hofac73cvpm5g"}
-        values: "1x30"
+        values: "1x75"
       # Count unready instances as well
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cq1636iqbcns73fiki8g"}
-        values: "0x30"
+        values: "0x75"
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cr2o56pjctnc739qmqv0"}
-        values: "0x5 1x25"
+        values: "0x15 1x60"
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 30m
         alertname: RHACSFleetshardSyncCentralCountPodMismatch
         exp_alerts: []
-      - eval_time: 25m
+      - eval_time: 61m
         alertname: RHACSFleetshardSyncCentralCountPodMismatch
         exp_alerts:
           - exp_labels:
@@ -28,27 +28,27 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Fleetshard synchronizer manages 4 centrals while the central pod count is 3."
-              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
+              description: "For the last 45 minutes, the number of ready Centrals returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
   # Test an instance is deleted but the pod still exists
   - interval: 1m
     input_series:
-      - series: acs_fleetshard_total_centrals
-        values: "4x5 3x25"
+      - series: acs_fleetshard_ready_centrals
+        values: "4x15 3x60"
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-co1cgv2hofac73cvpm5g"}
-        values: "1x30"
+        values: "1x75"
       # Count unready instances as well
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cq1636iqbcns73fiki8g"}
-        values: "0x30"
+        values: "0x75"
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cr2o56pjctnc739qmqv0"}
-        values: "0x5 1x25"
+        values: "0x15 1x60"
       - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cu3nrb4qls9s73emtae0"}
-        values: "1x30"
+        values: "1x75"
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 30m
         alertname: RHACSFleetshardSyncCentralCountPodMismatch
         exp_alerts: [ ]
-      - eval_time: 25m
+      - eval_time: 61m
         alertname: RHACSFleetshardSyncCentralCountPodMismatch
         exp_alerts:
           - exp_labels:
@@ -56,5 +56,5 @@ tests:
               severity: warning
             exp_annotations:
               summary: "Fleetshard synchronizer manages 3 centrals while the central pod count is 4."
-              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
+              description: "For the last 45 minutes, the number of ready Centrals returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
               sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"

--- a/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountPodMismatch.yaml
+++ b/resources/prometheus/unit_tests/RHACSFleetshardSyncCentralCountPodMismatch.yaml
@@ -1,0 +1,60 @@
+rule_files:
+  - /tmp/prometheus-rules-test.yaml
+
+evaluation_interval: 1m
+
+tests:
+  # Test new instance created but pod doesn't exist
+  - interval: 1m
+    input_series:
+      - series: acs_fleetshard_total_centrals
+        values: "3x5 4x25"
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-co1cgv2hofac73cvpm5g"}
+        values: "1x30"
+      # Count unready instances as well
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cq1636iqbcns73fiki8g"}
+        values: "0x30"
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cr2o56pjctnc739qmqv0"}
+        values: "0x5 1x25"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RHACSFleetshardSyncCentralCountPodMismatch
+        exp_alerts: []
+      - eval_time: 25m
+        alertname: RHACSFleetshardSyncCentralCountPodMismatch
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSFleetshardSyncCentralCountPodMismatch
+              severity: warning
+            exp_annotations:
+              summary: "Fleetshard synchronizer manages 4 centrals while the central pod count is 3."
+              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"
+  # Test an instance is deleted but the pod still exists
+  - interval: 1m
+    input_series:
+      - series: acs_fleetshard_total_centrals
+        values: "4x5 3x25"
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-co1cgv2hofac73cvpm5g"}
+        values: "1x30"
+      # Count unready instances as well
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cq1636iqbcns73fiki8g"}
+        values: "0x30"
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cr2o56pjctnc739qmqv0"}
+        values: "0x5 1x25"
+      - series: kube_deployment_status_replicas_ready{deployment="central", namespace="rhacs-cu3nrb4qls9s73emtae0"}
+        values: "1x30"
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: RHACSFleetshardSyncCentralCountPodMismatch
+        exp_alerts: [ ]
+      - eval_time: 25m
+        alertname: RHACSFleetshardSyncCentralCountPodMismatch
+        exp_alerts:
+          - exp_labels:
+              alertname: RHACSFleetshardSyncCentralCountPodMismatch
+              severity: warning
+            exp_annotations:
+              summary: "Fleetshard synchronizer manages 3 centrals while the central pod count is 4."
+              description: "For the last 15 minutes, the number of Central returned from Fleet Manager in Fleetshard Sync is different from the number of Central pods on the cluster. This may be a sign of a reconciliation breakdown and the Central SLI metrics may not match the actual state."
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-007-fleetshard-sync-reconciliation-error.md"


### PR DESCRIPTION
Add 2 alerts that may indicate that Central SLO metrics are undefined:

1. Compare total central count and the number of central pods;
2. Compare total central count and the number of central healthcheck probes.