### PR TITLE
fix: alert for SC drop and make it a warning for now

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -1045,11 +1045,11 @@ spec:
             sop_url: "TODO: SoP URL"
         - alert: DataPlaneCriticalSecuredClusterDrop
           expr: |
-            rhacs:cluster:central:rhacs_secured_cluster_diff < 50
+            rhacs:cluster:central:rhacs_secured_cluster_diff < 0.5
             and avg_over_time(sum(rox_central_secured_clusters)[7d:]) > 5
           for: 2h
           labels:
-            severity: critical
+            severity: warning # TODO: change to critical once we're confident this is not to sensitive
           annotations:
             summary: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
             description: ACS CS data plane cluster lost over 50% of secured clusters over all tenants

--- a/resources/prometheus/unit_tests/SecuredClusterDrop.yaml
+++ b/resources/prometheus/unit_tests/SecuredClusterDrop.yaml
@@ -81,7 +81,7 @@ tests:
         exp_alerts:
           - exp_labels:
               alertname: DataPlaneCriticalSecuredClusterDrop
-              severity: critical
+              severity: warning
             exp_annotations:
               summary: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
               description: ACS CS data plane cluster lost over 50% of secured clusters over all tenants


### PR DESCRIPTION
The alert definition for SC drops is wrong it should be `< 0.5` as opposed to `< 50` for the expression.

additionally I changed the severity to warning so we can monitor and tune this for some time before making it critical which causes paging via PagerDuty. 