### PR TITLE
ROX-28713: add SOP URL for secured cluster drop alerts

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -1028,7 +1028,7 @@ spec:
           annotations:
             summary: Tenant '{{ $labels.namespace }}' lost at least 20% of its secured clusters
             description: Tenant '{{ $labels.namespace }}' lost at least 20% of its secured clusters
-            sop_url: "TODO: SoP URL"
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"
         - expr: |
               sum(rox_central_secured_clusters) / max_over_time(sum(rox_central_secured_clusters)[7d:])
           record: rhacs:cluster:central:rhacs_secured_cluster_diff
@@ -1042,7 +1042,7 @@ spec:
           annotations:
             summary: ACS CS data plane cluster lost over 25% of secured clusters over all tenants
             description: ACS CS data plane cluster lost over 25% of secured clusters over all tenants
-            sop_url: "TODO: SoP URL"
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"
         - alert: DataPlaneCriticalSecuredClusterDrop
           expr: |
             rhacs:cluster:central:rhacs_secured_cluster_diff < 0.5
@@ -1053,4 +1053,4 @@ spec:
           annotations:
             summary: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
             description: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
-            sop_url: "TODO: SoP URL"
+            sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"

--- a/resources/prometheus/unit_tests/SecuredClusterDrop.yaml
+++ b/resources/prometheus/unit_tests/SecuredClusterDrop.yaml
@@ -26,7 +26,7 @@ tests:
             exp_annotations:
               summary: "Tenant 'rhacs-test' lost at least 20% of its secured clusters"
               description: "Tenant 'rhacs-test' lost at least 20% of its secured clusters"
-              sop_url: "TODO: SoP URL"
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"
   # DataPlaneSecuredClusterDrop trigger for clusters > 5 overall cores
   - interval: 1m
     input_series:
@@ -48,7 +48,7 @@ tests:
             exp_annotations:
               summary: ACS CS data plane cluster lost over 25% of secured clusters over all tenants
               description: ACS CS data plane cluster lost over 25% of secured clusters over all tenants
-              sop_url: "TODO: SoP URL"
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"
     # DataPlaneSecuredClusterDrop does not trigger for clusters < 5 overall cores
   - interval: 1m
     input_series:
@@ -85,7 +85,7 @@ tests:
             exp_annotations:
               summary: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
               description: ACS CS data plane cluster lost over 50% of secured clusters over all tenants
-              sop_url: "TODO: SoP URL"
+              sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-060-secured-cluster-drop-alert.md"
   # DataPlaneCriticalSecuredClusterDrop does not trigger for clusters < 5 overall cores
   - interval: 1m
     input_series:


### PR DESCRIPTION
Add the URL of the SoP for secured cluster drop alerts.