### PR TITLE
ROX-29371: change error budget alerting for less noise

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -684,7 +684,7 @@ spec:
             message: "High availability error budget exhaustion for central. Current exhaustion: {{ $value | humanizePercentage }}."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
           expr: |
-            central:slo:availability:error_budget_exhaustion >= 0.9 and central:sli:availability >= 0
+            central:slo:availability:error_budget_exhaustion >= 0.9 and min_over_time(central:sli:availability[1h]) == 0
           labels:
             service: central
             severity: critical
@@ -696,7 +696,7 @@ spec:
             message: "High availability error budget exhaustion for central. Current exhaustion: {{ $value | humanizePercentage }}."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
           expr: |
-            central:slo:availability:error_budget_exhaustion >= 0.7 and central:sli:availability >= 0
+            central:slo:availability:error_budget_exhaustion >= 0.7 and min_over_time(central:sli:availability[1h]) == 0
           labels:
             service: central
             severity: warning
@@ -708,7 +708,7 @@ spec:
             message: "High availability error budget exhaustion for central. Current exhaustion: {{ $value | humanizePercentage }}."
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-018-rhacs-central-slo-alerts.md"
           expr: |
-            central:slo:availability:error_budget_exhaustion >= 0.5 and central:sli:availability >= 0
+            central:slo:availability:error_budget_exhaustion >= 0.5 and min_over_time(central:sli:availability[1h]) == 0
           labels:
             service: central
             severity: warning
@@ -734,7 +734,7 @@ spec:
           # Corresponds to less than 50% up time over 1 hour assuming a 99% SLO target.
           # See recording rules for how burn rates relate to SLI and SLO in general.
           expr: |
-            central:slo:availability:burnrate1h >= 50 and central:sli:availability >= 0
+            central:slo:availability:burnrate1h >= 50 and min_over_time(central:sli:availability[1h])
           labels:
             service: central
             severity: critical


### PR DESCRIPTION
The error budget alerting is producing a lot of noise in case of incidents, because it fires for 28 days after the incident though no tenants are down anymore.

This PR changes the budget alert to only fire if central availability was 0 in the last hour.

