### PR TITLE
ROX-30068: disable memory utilization alerts for scanner-db

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -252,7 +252,7 @@ spec:
           record: rhacs_tenants:namespace:pod:container:max_memory_usage_ratio
         - alert: RHACSTenantWorkloadMemoryUtilizationHigh
           expr: |
-            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio >= 0.9
+            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio{container=~"central|scanner|indexer|matcher"} >= 0.9
           for: 30m
           labels:
             severity: warning
@@ -262,7 +262,7 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-cloud-service/runbooks/-/blob/master/sops/dp-039-tenant-workload-memory-utilization-high.md"
         - alert: RHACSTenantWorkloadMemoryUtilizationCritical
           expr: |
-            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio{container=~"central|scanner|db|indexer|matcher"} >= 0.95
+            rhacs_tenants:namespace:pod:container:max_memory_usage_ratio{container=~"central|scanner|indexer|matcher"} >= 0.95
           for: 10m
           labels:
             severity: critical


### PR DESCRIPTION
We're going to disable scanner-db high memory alerting, because we have metrics reporting issues.

See tickets and ticket comments for reasoning:
- [ROX-30068](https://issues.redhat.com/browse/ROX-30068)
- [ROX-30025](https://issues.redhat.com/browse/ROX-30025)

With this change we won't get alerted for high memory usage anymore, but we still have alerts for OOMs which will let us know if scaling is required.
