### PR TITLE
ROX-34459: fix scanner restart noise

### DIFF
--- a/resources/prometheus/prometheus-rules.yaml
+++ b/resources/prometheus/prometheus-rules.yaml
@@ -72,7 +72,7 @@ spec:
             sop_url: "https://gitlab.cee.redhat.com/stackrox/acs-managed-service-runbooks/blob/master/sops/dp-003-rhacs-instance-unavailable.md"
         - alert: RHACSScannerContainerFrequentlyRestarting
           expr: |
-            increase(kube_pod_container_status_restarts_total{pod=~"scanner.*", container=~"scanner|db|matcher|indexer"}[30m]) > 4
+            changes(kube_pod_container_status_restarts_total{pod=~"scanner.*", container=~"scanner|db|matcher|indexer"}[30m]) > 4
           labels:
             severity: warning
           annotations:

--- a/scripts/lint-grafana.sh
+++ b/scripts/lint-grafana.sh
@@ -3,7 +3,9 @@
 set -eu
 
 if ! [ -x "$(command -v dashboard-lint)" ]; then
-	go install github.com/grafana/dashboard-linter@latest
+	# using this specific commit as linter installation via go install broke
+	# because grafana started to use replace directive in their go.mod which does not support go install anymore
+	go install github.com/grafana/dashboard-linter@a088406
 fi
 
 ! [ -x "$(command -v yq)" ] && echo 'yq not installed, the hook requires it.' && exit 1


### PR DESCRIPTION
Changing the restart alert for scanner restarts to use `changes(...)[30m]` as opposed to `increase(...)[30m]`
This PR also pins the grafana linter as the latest version broke the go install flow by using replace directives in their go.mod.

Because of the float vs int nature and prometheus extrapolations `increase` can produce inflated values, leading to false positive alerts for scanner restarts.

Looking at the graphs it appears that changes() capture our intent to exclude restarts and updates from the alerting much better. 

<img width="1894" height="742" alt="image" src="https://github.com/user-attachments/assets/7a7decab-f6f6-4fe1-9a1d-6545d97a2b87" />


Full claude explanation:
```
increase() in Prometheus doesn't just compute last_sample - first_sample. It looks at the
  actual time span covered by the samples within the window and then scales the result to cover
  the full requested window.

  Example with a 30m window and 60s scrape interval:

  - The first sample in the window is at t+28s, the last at t+29m31s
  - That's ~29m03s of actual sample coverage
  - The raw difference between those samples is 3 restarts
  - Prometheus scales: 3 × (30m / 29m03s) ≈ 3.1

  That's mild. But it gets worse when restarts happen near the window edges, because Prometheus
  also extrapolates beyond the first and last samples by up to half a scrape interval on each
  side. The exact math depends on sample timing and can push a real count of 3 to 4+.

  With counter resets (which happen on every container restart), each reset adds additional
  imprecision to the calculation because Prometheus has to infer the pre-reset value from
  surrounding samples.

  This is a known Prometheus behavior — increase() on a counter that increments in whole numbers
  can return non-integer, inflated values. That's why round(increase(...)) or using changes()
  instead is common when you care about exact counts.
```