### PR TITLE
ROX-34665: Add Scans per Day by Namespace panel to cluster overview

### DIFF
--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
@@ -1474,9 +1474,7 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": [
-                "sum"
-              ],
+              "reducer": ["sum"],
               "show": false
             },
             "showHeader": true,
@@ -1943,9 +1941,7 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": [
-                "sum"
-              ],
+              "reducer": ["sum"],
               "show": false
             },
             "showHeader": true,
@@ -2220,9 +2216,7 @@ spec:
             "cellHeight": "sm",
             "footer": {
               "show": false,
-              "reducer": [
-                "sum"
-              ],
+              "reducer": ["sum"],
               "countRows": false,
               "fields": ""
             },
@@ -2336,9 +2330,7 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": [
-                "sum"
-              ],
+              "reducer": ["sum"],
               "show": false
             },
             "showHeader": true,
@@ -2471,9 +2463,7 @@ spec:
               "options": {
                 "fields": {
                   "Expiration": {
-                    "aggregations": [
-                      "last"
-                    ],
+                    "aggregations": ["last"],
                     "operation": "aggregate"
                   },
                   "Key": {
@@ -2481,9 +2471,7 @@ spec:
                     "operation": "groupby"
                   },
                   "Namespace": {
-                    "aggregations": [
-                      "last"
-                    ],
+                    "aggregations": ["last"],
                     "operation": "groupby"
                   },
                   "Secret": {
@@ -2522,20 +2510,14 @@ spec:
       ],
       "revision": 1,
       "schemaVersion": 39,
-      "tags": [
-        "rhacs"
-      ],
+      "tags": ["rhacs"],
       "templating": {
         "list": [
           {
             "current": {
               "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
+              "text": ["All"],
+              "value": ["$__all"]
             },
             "datasource": {
               "type": "prometheus",
@@ -2562,12 +2544,8 @@ spec:
           {
             "current": {
               "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
+              "text": ["All"],
+              "value": ["$__all"]
             },
             "datasource": {
               "type": "prometheus",
@@ -2594,12 +2572,8 @@ spec:
           {
             "current": {
               "selected": true,
-              "text": [
-                "All"
-              ],
-              "value": [
-                "$__all"
-              ]
+              "text": ["All"],
+              "value": ["$__all"]
             },
             "datasource": {
               "type": "prometheus",

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
@@ -1474,7 +1474,9 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": ["sum"],
+              "reducer": [
+                "sum"
+              ],
               "show": false
             },
             "showHeader": true,
@@ -1941,7 +1943,9 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": ["sum"],
+              "reducer": [
+                "sum"
+              ],
               "show": false
             },
             "showHeader": true,
@@ -2132,12 +2136,151 @@ spec:
           "type": "table"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "color": {
+                "mode": "thresholds"
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "namespace\\namespace"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 236
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "namespace\\Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 232
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2026-05-08"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 122
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 85
+          },
+          "id": 150,
+          "interval": "1d",
+          "maxDataPoints": 30,
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            },
+            "sortBy": [
+              {
+                "displayName": "namespace\\Time",
+                "desc": true
+              }
+            ]
+          },
+          "pluginVersion": "11.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum by (namespace) (increase(rox_central_scan_duration_count[1d]))",
+              "format": "table",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "$_relativeTime/d",
+          "timeShift": "$_timeShift/d",
+          "title": "Scans per Day by Namespace",
+          "transformations": [
+            {
+              "id": "formatTime",
+              "options": {
+                "outputFormat": "YYYY-MM-DD",
+                "timeField": "Time",
+                "useTimezone": true
+              }
+            },
+            {
+              "id": "groupingToMatrix",
+              "options": {
+                "columnField": "Time",
+                "rowField": "namespace",
+                "valueField": "Value"
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 85
+            "y": 93
           },
           "id": 149,
           "panels": [],
@@ -2184,7 +2327,7 @@ spec:
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 86
+            "y": 94
           },
           "id": 148,
           "options": {
@@ -2193,7 +2336,9 @@ spec:
               "countRows": false,
               "enablePagination": true,
               "fields": "",
-              "reducer": ["sum"],
+              "reducer": [
+                "sum"
+              ],
               "show": false
             },
             "showHeader": true,
@@ -2326,7 +2471,9 @@ spec:
               "options": {
                 "fields": {
                   "Expiration": {
-                    "aggregations": ["last"],
+                    "aggregations": [
+                      "last"
+                    ],
                     "operation": "aggregate"
                   },
                   "Key": {
@@ -2334,7 +2481,9 @@ spec:
                     "operation": "groupby"
                   },
                   "Namespace": {
-                    "aggregations": ["last"],
+                    "aggregations": [
+                      "last"
+                    ],
                     "operation": "groupby"
                   },
                   "Secret": {
@@ -2373,14 +2522,20 @@ spec:
       ],
       "revision": 1,
       "schemaVersion": 39,
-      "tags": ["rhacs"],
+      "tags": [
+        "rhacs"
+      ],
       "templating": {
         "list": [
           {
             "current": {
               "selected": true,
-              "text": ["All"],
-              "value": ["$__all"]
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
             },
             "datasource": {
               "type": "prometheus",
@@ -2407,8 +2562,12 @@ spec:
           {
             "current": {
               "selected": true,
-              "text": ["All"],
-              "value": ["$__all"]
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
             },
             "datasource": {
               "type": "prometheus",
@@ -2435,8 +2594,12 @@ spec:
           {
             "current": {
               "selected": true,
-              "text": ["All"],
-              "value": ["$__all"]
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
             },
             "datasource": {
               "type": "prometheus",

--- a/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
+++ b/resources/grafana/generated/dashboards/rhacs-cluster-overview.yaml
@@ -2247,7 +2247,7 @@ spec:
           ],
           "timeFrom": "$_relativeTime/d",
           "timeShift": "$_timeShift/d",
-          "title": "Scans per Day by Namespace",
+          "title": "Scans per 24h by Namespace",
           "transformations": [
             {
               "id": "formatTime",

--- a/resources/grafana/sources/.claude/settings.local.json
+++ b/resources/grafana/sources/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(//home/ebenshet/workspaces/rox-34665-grafana-display-scans-per-day/github.com/stackrox/rhacs-observability-resources/**)",
+      "Bash(jj status *)",
+      "Bash(jj rebase *)",
+      "Bash(rm -f resources/grafana/generated/dashboards/new-panel.yaml resources/grafana/sources/.claude/settings.local.json)",
+      "Bash(rmdir resources/grafana/sources/.claude)",
+      "Bash(jj commit -m 'ROX-34665: Add Scans per Day by Namespace panel to cluster overview dashboard *)"
+    ]
+  }
+}

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -1462,7 +1462,9 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -1929,7 +1931,9 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -2120,12 +2124,151 @@
       "type": "table"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "namespace\\namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 236
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "namespace\\Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 232
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2026-05-08"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 122
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 150,
+      "interval": "1d",
+      "maxDataPoints": 30,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
+        "sortBy": [
+          {
+            "displayName": "namespace\\Time",
+            "desc": true
+          }
+        ]
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (namespace) (increase(rox_central_scan_duration_count[1d]))",
+          "format": "table",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "$_relativeTime/d",
+      "timeShift": "$_timeShift/d",
+      "title": "Scans per Day by Namespace",
+      "transformations": [
+        {
+          "id": "formatTime",
+          "options": {
+            "outputFormat": "YYYY-MM-DD",
+            "timeField": "Time",
+            "useTimezone": true
+          }
+        },
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "Time",
+            "rowField": "namespace",
+            "valueField": "Value"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 93
       },
       "id": 149,
       "panels": [],
@@ -2172,7 +2315,7 @@
         "h": 13,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 94
       },
       "id": 148,
       "options": {
@@ -2181,7 +2324,9 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": ["sum"],
+          "reducer": [
+            "sum"
+          ],
           "show": false
         },
         "showHeader": true,
@@ -2314,7 +2459,9 @@
           "options": {
             "fields": {
               "Expiration": {
-                "aggregations": ["last"],
+                "aggregations": [
+                  "last"
+                ],
                 "operation": "aggregate"
               },
               "Key": {
@@ -2322,7 +2469,9 @@
                 "operation": "groupby"
               },
               "Namespace": {
-                "aggregations": ["last"],
+                "aggregations": [
+                  "last"
+                ],
                 "operation": "groupby"
               },
               "Secret": {
@@ -2361,14 +2510,20 @@
   ],
   "revision": 1,
   "schemaVersion": 39,
-  "tags": ["rhacs"],
+  "tags": [
+    "rhacs"
+  ],
   "templating": {
     "list": [
       {
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",
@@ -2395,8 +2550,12 @@
       {
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",
@@ -2423,8 +2582,12 @@
       {
         "current": {
           "selected": true,
-          "text": ["All"],
-          "value": ["$__all"]
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
         "datasource": {
           "type": "prometheus",

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -1462,9 +1462,7 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -1931,9 +1929,7 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -2208,9 +2204,7 @@
         "cellHeight": "sm",
         "footer": {
           "show": false,
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "countRows": false,
           "fields": ""
         },
@@ -2324,9 +2318,7 @@
           "countRows": false,
           "enablePagination": true,
           "fields": "",
-          "reducer": [
-            "sum"
-          ],
+          "reducer": ["sum"],
           "show": false
         },
         "showHeader": true,
@@ -2459,9 +2451,7 @@
           "options": {
             "fields": {
               "Expiration": {
-                "aggregations": [
-                  "last"
-                ],
+                "aggregations": ["last"],
                 "operation": "aggregate"
               },
               "Key": {
@@ -2469,9 +2459,7 @@
                 "operation": "groupby"
               },
               "Namespace": {
-                "aggregations": [
-                  "last"
-                ],
+                "aggregations": ["last"],
                 "operation": "groupby"
               },
               "Secret": {
@@ -2510,20 +2498,14 @@
   ],
   "revision": 1,
   "schemaVersion": 39,
-  "tags": [
-    "rhacs"
-  ],
+  "tags": ["rhacs"],
   "templating": {
     "list": [
       {
         "current": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
@@ -2550,12 +2532,8 @@
       {
         "current": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",
@@ -2582,12 +2560,8 @@
       {
         "current": {
           "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": ["All"],
+          "value": ["$__all"]
         },
         "datasource": {
           "type": "prometheus",

--- a/resources/grafana/sources/rhacs-cluster-overview.json
+++ b/resources/grafana/sources/rhacs-cluster-overview.json
@@ -2235,7 +2235,7 @@
       ],
       "timeFrom": "$_relativeTime/d",
       "timeShift": "$_timeShift/d",
-      "title": "Scans per Day by Namespace",
+      "title": "Scans per 24h by Namespace",
       "transformations": [
         {
           "id": "formatTime",


### PR DESCRIPTION
## Summary

- Adds a new "Scans per Day by Namespace" table panel to the `rhacs-cluster-overview` Grafana dashboard
- Panel placed directly after the Scanner Overview Table at full width (w=24)
- Uses `increase(rox_central_scan_duration_count[1d])` with matrix transform to show daily scan counts per namespace as date columns

<img width="2129" height="352" alt="image" src="https://github.com/user-attachments/assets/64d096e6-1871-43a4-b0ee-cdbf79273aa9" />


## Details

The panel uses the existing `$_relativeTime` and `$_timeShift` dashboard variables to control the time window. Results are formatted as a pivot table with namespaces as rows and dates (YYYY-MM-DD) as columns.

## Test plan

- [ ] Verify panel renders correctly in Grafana staging
- [ ] Confirm date columns populate with scan count data
- [ ] Check panel positioning relative to Scanner Overview Table and Certificate Expiry section

🔗 [ROX-34665](https://issues.redhat.com/browse/ROX-34665)

[ROX-34665]: https://redhat.atlassian.net/browse/ROX-34665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ