### PR TITLE
ROX-34664: Disable KubePersistentVolumeFillingUp for scanner-db

### DIFF
--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -414,6 +414,7 @@
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
+      unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}
     "for": "1h"
     "labels":
       "severity": "warning"

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -63,6 +63,20 @@ kubernetes {
                 group.rules
               ),
             }
+          else if group.name == 'kubernetes-storage' then
+            group {
+              rules: std.map(
+                function(rule)
+                  if rule.alert == 'KubePersistentVolumeFillingUp' && rule.labels.severity == 'warning' then
+                    rule {
+                      // Exclude scanner-db PVCs from warning alerts because scanner-db dynamically grows/shrinks.
+                      expr: std.rstripChars(rule.expr, '\n') + '\nunless on(%(clusterLabel)s, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}\n' % $._config,
+                    }
+                  else
+                    rule,
+                group.rules
+              ),
+            }
           else if group.name == 'kubernetes-system-kubelet' then
             group {
               rules: std.filter(

--- a/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
@@ -422,6 +422,7 @@ spec:
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
+            unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}
           "for": "1h"
           "labels":
             "severity": "warning"


### PR DESCRIPTION
KubePersistentVolumeFillingUp warning alert is noisy for scanner-db. Becasue scanner-db can grow/shrink in size.
There is still KubePersistentVolumeFillingUp critical alert in case scanner-db PVC is full.