### PR TITLE
ROX-34664: Disable KubePersistentVolumeFillingUp for prometheus

### DIFF
--- a/resources/mixins/kubernetes/generated/alerts.yml
+++ b/resources/mixins/kubernetes/generated/alerts.yml
@@ -414,7 +414,7 @@
       kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
       unless on(cluster, namespace, persistentvolumeclaim)
       kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
-      unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}
+      unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*|prometheus-data-prometheus-k8s.*"}
     "for": "1h"
     "labels":
       "severity": "warning"

--- a/resources/mixins/kubernetes/mixin.libsonnet
+++ b/resources/mixins/kubernetes/mixin.libsonnet
@@ -69,8 +69,9 @@ kubernetes {
                 function(rule)
                   if rule.alert == 'KubePersistentVolumeFillingUp' && rule.labels.severity == 'warning' then
                     rule {
-                      // Exclude scanner-db PVCs from warning alerts because scanner-db dynamically grows/shrinks.
-                      expr: std.rstripChars(rule.expr, '\n') + '\nunless on(%(clusterLabel)s, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}\n' % $._config,
+                      // Exclude scanner-db and prometheus PVCs from warning alerts.
+                      // scanner-db and prometheus PVC dynamically grow/shrink. They might fluctuate around warning threshold.
+                      expr: std.rstripChars(rule.expr, '\n') + '\nunless on(%(clusterLabel)s, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*|prometheus-data-prometheus-k8s.*"}\n' % $._config,
                     }
                   else
                     rule,

--- a/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
+++ b/resources/prometheus/generated/kubernetes-mixin-alerts.yaml
@@ -422,7 +422,7 @@ spec:
             kube_persistentvolumeclaim_access_mode{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*", access_mode="ReadOnlyMany"} == 1
             unless on(cluster, namespace, persistentvolumeclaim)
             kube_persistentvolumeclaim_labels{namespace!~"openshift-kube.*|openshift-logging|openshift-marketplace|openshift-aws-vpce-operator|openshift-deployment.*|kube.*",label_excluded_from_alerts="true"} == 1
-            unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*"}
+            unless on(cluster, namespace, persistentvolumeclaim) kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"scanner-db.*|prometheus-data-prometheus-k8s.*"}
           "for": "1h"
           "labels":
             "severity": "warning"


### PR DESCRIPTION
Disable warning for prometheus PVC. Example noisy alert: https://redhat.pagerduty.com/incidents/Q0WCIAA3SWN0F9 